### PR TITLE
Naming convention update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ file(GLOB capi_source_files
 	"Source/jpg.c"
 	"Source/png.c"
 	"Source/ico.c"
+	"Source/strings.c"
 )
 
 file(GLOB zlib_header_files

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -123,12 +123,12 @@ typedef char UTF8;    // UTF8 Unit
 #ifdef _MSC_VER
 typedef wchar_t UTF16;  // UTF16 Unit
 #else
-typedef U16 UTF16;  // UTF16 Unit
+typedef U16 UTF16;    // UTF16 Unit
 #endif
 #ifdef __GNUC__
 typedef wchar_t UTF32;  // UTF32 Unit
 #else
-typedef U32 UTF32;  // UTF32 Unit
+typedef U32 UTF32;    // UTF32 Unit
 #endif
 
 #ifdef UNICODE
@@ -264,7 +264,7 @@ PACK(STRUCT(ICO)
 *
 PNG_PARAMETERS
 * CompressionMethod [PNG compression method] 0 = zlib
-* Level [The compression level] If CompressionMethod is set to (zlib) This may be any value 0-9 or one the the following constants:
+* Level [The compression level] If CompressionMethod is set to (zlib) This may be any value 0-9 or one of the following constants:
 Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
 * FilterMethod [The filter method] 0 = filter method 0
 * InterlaceMethod [The interlace method] 0 = interlace method 0 (null method), 1 = interlace method 1 (Adam7 method)
@@ -325,7 +325,7 @@ extern "C" {
 	z_def_file - Compress from file source to file destination until EOF on source (zpipe.c)
 	* dest [A file stream opened with fopen to write]
 	* source [A file stream opened with fopen to read]
-	* level [The compression level] This may be any value 0-9 or one the the following constants: Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
+	* level [The compression level] This may be any value 0-9 or one of the following constants: Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
 	* returns Z_OK on success
 	*
 	*/
@@ -348,7 +348,7 @@ extern "C" {
 	* desLen [Pointer to a uLong variable to receive the number of bytes outputted to dest]
 	* src [The source file in memory to compress]
 	* srcLen [The source file size in bytes]
-	* level [The compression level] This may be any value 0-9 or one the the following constants: Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
+	* level [The compression level] This may be any value 0-9 or one of the following constants: Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
 	* returns Z_OK on success
 	*
 	*/
@@ -784,7 +784,7 @@ extern "C" {
 
 	/*
 	*
-	capi_StrAppendA - Appends a ASCII string (strings.c)
+	capi_StrAppendA - Append a ASCII string (strings.c)
 	* Destination [Null-terminated destination string buffer]
 	* Length [Length of the destination string buffer in ASCII units]
 	* Source [Null-terminated source string buffer]
@@ -930,7 +930,7 @@ extern "C" {
 	*
 	capi_StrUnitsU - Get the number of UTF8 units in a UTF8 string (strings.c)
 	* String [Pointer to a null-terminated string]
-	* returns the the number of UTF8 units in the string, not including the terminating null character
+	* returns the number of UTF8 units in the string, not including the terminating null character
 	* -1 is returned for an invalid parameter
 	*
 	*/
@@ -951,7 +951,7 @@ extern "C" {
 
 	/*
 	*
-	capi_StrAppendU - Appends a UTF8 string (strings.c)
+	capi_StrAppendU - Append a UTF8 string (strings.c)
 	* Destination [Null-terminated destination string buffer]
 	* Length [Length of the destination string buffer in UTF8 units]
 	* Source [Null-terminated source string buffer]
@@ -1097,7 +1097,7 @@ extern "C" {
 	*
 	capi_StrUnitsW - Get the number of UTF16 units in a UTF16 string (strings.c)
 	* String [Pointer to a null-terminated string]
-	* returns the the number of UTF16 units in the string, not including the terminating null character
+	* returns the number of UTF16 units in the string, not including the terminating null character
 	* -1 is returned for an invalid parameter
 	* To get the size of the string in bytes, multiply the result by sizeof(UTF16)
 	*
@@ -1119,7 +1119,7 @@ extern "C" {
 
 	/*
 	*
-	capi_StrAppendW - Appends a UTF16 string (strings.c)
+	capi_StrAppendW - Append a UTF16 string (strings.c)
 	* Destination [Null-terminated destination string buffer]
 	* Length [Length of the destination string buffer in UTF16 units]
 	* Source [Null-terminated source string buffer]
@@ -1232,7 +1232,7 @@ extern "C" {
 
 	/*
 	*
-	capi_StrAppendL - Appends a UTF32 string (strings.c)
+	capi_StrAppendL - Append a UTF32 string (strings.c)
 	* Destination [Null-terminated destination string buffer]
 	* Length [Length of the destination string buffer in UTF32 units]
 	* Source [Null-terminated source string buffer]

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -118,13 +118,26 @@ typedef signed long long I64;
 PACK(STRUCT(I128) { U64 Lo; I64 Hi; });
 PACK(STRUCT(I256) { U128 Lo; I128 Hi; });
 
+typedef I8 ASCII;   // ASCII Unit
+typedef U8 UTF8;    // UTF8 Unit
+#ifdef _MSC_VER
+typedef wchar_t UTF16;  // UTF16 Unit
+#else
+typedef U16 UTF16;  // UTF16 Unit
+#endif
+#ifdef __GNUC__
+typedef wchar_t UTF32;  // UTF32 Unit
+#else
+typedef U32 UTF32;  // UTF32 Unit
+#endif
+
 #ifdef UNICODE
-typedef wchar_t STRING;
+typedef UTF16 STRING;
 #define STR(String) L##String
 #define capi_Version capi_VersionW
 #define capi_ErrorCodeToString capi_ErrorCodeToStringW
 #else
-typedef char STRING;
+typedef UTF8 STRING;
 #define STR(String) String
 #define capi_Version capi_VersionA
 #define capi_ErrorCodeToString capi_ErrorCodeToStringA
@@ -745,6 +758,645 @@ extern "C" {
 	*
 	*/
 	CAPI_FUNC(I32) capi_Create_ICO_ToMemory(ICO** ppFilePointer, U64* pFileSize, IMAGE* pImageList, U16 nImages, U8 Format, void* pParameters);
+
+	/*
+	*
+	capi_StrLenA - Get the length of a ASCII string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the number of characters in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrLenA(ASCII* String);
+
+	/*
+	*
+	capi_StrCopyA - Copy a ASCII string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in ASCII units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters copied to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, ASCII* Source);
+
+	/*
+	*
+	capi_StrAppendA - Appends a ASCII string (strings.c)
+	* Destination [Null-terminated destination string buffer]
+	* Length [Length of the destination string buffer in ASCII units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters appended to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, ASCII* Source);
+
+	/*
+	*
+	capi_StrCompareA - Compare ASCII strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareA(ASCII* String1, ASCII* String2);
+
+	/*
+	*
+	capi_StrCompareInsensitiveA - Perform a case-insensitive comparison of ASCII strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveA(ASCII* String1, ASCII* String2);
+
+	/*
+	*
+	capi_StrFindA - Find a character in a ASCII string (strings.c)
+	* String [Null-terminated source string to search]
+	* Delimit [Character to be located]
+	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+	*
+	*/
+	CAPI_FUNC(ASCII*) capi_StrFindA(ASCII* String, ASCII Delimit);
+
+	/*
+	*
+	capi_StrFindStrA - Find a ASCII string in a ASCII string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit);
+
+	/*
+	*
+	capi_StrFindStrInsensitiveA - Perform a case-insensitive search for a ASCII string in a ASCII string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(ASCII* String, ASCII* StrDelimit);
+
+	/*
+	*
+	capi_StrSplitA - Split a ASCII string (strings.c)
+	* String [Null-terminated source string to split]
+	* Delimit [Character to be located and replaced]
+	* returns a pointer to the ASCII string following the Delimit, or 0 if Delimit is not found
+	* When Delimit is found its set to 0
+	*
+	*/
+	CAPI_FUNC(ASCII*) capi_StrSplitA(ASCII* String, ASCII Delimit);
+
+	/*
+	*
+	capi_StrReverseA - Reverse a ASCII string (strings.c)
+	* String [Null-terminated source string to reverse]
+	*
+	*/
+	CAPI_FUNC(void) capi_StrReverseA(ASCII* String);
+
+	/*
+	*
+	capi_UTF8_GetCharSize - Get the number of bytes a UTF8 code-point encoding uses (strings.c)
+	* Code [The 1st UTF8 unit of the code-point encoding]
+	* returns the number of UTF8 units the code-point encoding uses, or 0 for an error
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF8_GetCharUnits(UTF8 Code);
+
+	/*
+	*
+	capi_UTF8_Encode_Unsafe - Encode a code-point using the UTF8 encoding (strings.c)
+	* String [The destination string buffer]
+	* CodePoint [The code-point to encode]
+	* returns the number of UTF8 units that was written to String, or 0 for an error
+	* This function does not check if String is valid and does not output any null-terminator character
+	* Consider using the safer version capi_UTF8_Encode
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF8_Encode_Unsafe(UTF8* String, U32 CodePoint);
+
+	/*
+	*
+	capi_UTF8_Encode - Encode a code-point using the UTF8 encoding (strings.c)
+	* String [The destination string buffer]
+	* Length [Length of the destination string buffer in UTF8 units]
+	* CodePoint [The code-point to encode]
+	* returns the number of UTF8 units that was written to String, not including the terminating null character, or 0 for an error
+	* This function does not check if String is valid
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF8_Encode(UTF8* String, size_t Length, U32 CodePoint);
+
+	/*
+	*
+	capi_UTF8_Decode - Decode a UTF8 encoding into a code-point (strings.c)
+	* Units [The number of UTF8 units the code-point uses] use capi_UTF8_GetCharUnits to get this value
+	* String [The source string to decode a code-point from]
+	* returns the decoded code-point, or 0 for an error
+	* This function does not check if String is valid
+	*
+	*/
+	CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, UTF8* String);
+
+	/*
+	*
+	capi_StrLenU - Get the length of a UTF8 string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the number of characters in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrLenU(UTF8* String);
+
+	/*
+	*
+	capi_StrUnitsU - Get the number of UTF8 units in a UTF8 string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the the number of UTF8 units in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrUnitsU(UTF8* String);
+
+	/*
+	*
+	capi_StrCopyU - Copy a UTF8 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF8 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF8 units copied to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, UTF8* Source);
+
+	/*
+	*
+	capi_StrAppendU - Appends a UTF8 string (strings.c)
+	* Destination [Null-terminated destination string buffer]
+	* Length [Length of the destination string buffer in UTF8 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF8 units appended to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, UTF8* Source);
+
+	/*
+	*
+	capi_StrCompareU - Compare UTF8 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareU(UTF8* String1, UTF8* String2);
+
+	/*
+	*
+	capi_StrCompareInsensitiveU - Perform a case-insensitive comparison of UTF8 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveU(UTF8* String1, UTF8* String2);
+
+	/*
+	*
+	capi_StrFindU - Find a character in a UTF8 string (strings.c)
+	* String [Null-terminated source string to search]
+	* Delimit [Character to be located]
+	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF8*) capi_StrFindU(UTF8* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrFindStrU - Find a UTF8 string in a UTF8 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit);
+
+	/*
+	*
+	capi_StrFindStrInsensitiveU - Perform a case-insensitive search for a UTF8 string in a UTF8 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(UTF8* String, UTF8* StrDelimit);
+
+	/*
+	*
+	capi_StrSplitU - Split a UTF8 string (strings.c)
+	* String [Null-terminated source string to split]
+	* Delimit [Character to be located and replaced]
+	* returns a pointer to the UTF8 string following the Delimit, or 0 if Delimit is not found
+	* When Delimit is found its set to 0
+	*
+	*/
+	CAPI_FUNC(UTF8*) capi_StrSplitU(UTF8* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrReverseU - Reverse a UTF8 string (strings.c)
+	* String [Null-terminated source string to reverse]
+	*
+	*/
+	CAPI_FUNC(void) capi_StrReverseU(UTF8* String);
+
+	/*
+	*
+	capi_UTF16_GetCharUnits - Get the number of words a UTF16 code-point encoding uses (strings.c)
+	* Code [The 1st UTF16 unit of the code-point encoding]
+	* returns the number of UTF16 units the code-point encoding uses, or 0 for an error
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF16_GetCharUnits(UTF16 Code);
+
+	/*
+	*
+	capi_UTF16_Encode_Unsafe - Encode a code-point using the UTF16 encoding (strings.c)
+	* String [The destination string buffer]
+	* CodePoint [The code-point to encode]
+	* returns the number of UTF16 units that was written to String, or 0 for an error
+	* This function does not check if String is valid and does not output any null-terminator character
+	* Consider using the safer version capi_UTF16_Encode
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF16_Encode_Unsafe(UTF16* String, U32 CodePoint);
+
+	/*
+	*
+	capi_UTF16_Encode - Encode a code-point using the UTF16 encoding (strings.c)
+	* String [The destination string buffer]
+	* Length [Length of the destination string buffer in UTF16 units]
+	* CodePoint [The code-point to encode]
+	* returns the number of UTF16 units that was written to String, not including the terminating null character, or 0 for an error
+	* This function does not check if String is valid
+	*
+	*/
+	CAPI_FUNC(U8) capi_UTF16_Encode(UTF16* String, size_t Length, U32 CodePoint);
+
+	/*
+	*
+	capi_UTF16_Decode - Decode a UTF16 encoding into a code-point (strings.c)
+	* Units [The number of UTF16 units the code-point uses] use capi_UTF16_GetCharUnits to get this value
+	* String [The source string to decode a code-point from]
+	* returns the decoded code-point, or 0 for an error
+	* This function does not check if String is valid
+	*
+	*/
+	CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, UTF16* String);
+
+	/*
+	*
+	capi_StrLenW - Get the length of a UTF16 string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the number of characters in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrLenW(UTF16* String);
+
+	/*
+	*
+	capi_StrUnitsW - Get the number of UTF16 units in a UTF16 string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the the number of UTF16 units in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	* To get the size of the string in bytes, multiply the result by sizeof(UTF16)
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrUnitsW(UTF16* String);
+
+	/*
+	*
+	capi_StrCopyW - Copy a UTF16 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF16 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF16 units copied to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, UTF16* Source);
+
+	/*
+	*
+	capi_StrAppendW - Appends a UTF16 string (strings.c)
+	* Destination [Null-terminated destination string buffer]
+	* Length [Length of the destination string buffer in UTF16 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF16 units appended to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, UTF16* Source);
+
+	/*
+	*
+	capi_StrCompareW - Compare UTF16 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareW(UTF16* String1, UTF16* String2);
+
+	/*
+	*
+	capi_StrCompareInsensitiveW - Perform a case-insensitive comparison of UTF16 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveW(UTF16* String1, UTF16* String2);
+
+	/*
+	*
+	capi_StrFindW - Find a character in a UTF16 string (strings.c)
+	* String [Null-terminated source string to search]
+	* Delimit [Character to be located]
+	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF16*) capi_StrFindW(UTF16* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrFindStrW - Find a UTF16 string in a UTF16 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit);
+
+	/*
+	*
+	capi_StrFindStrInsensitiveW - Perform a case-insensitive search for a UTF16 string in a UTF16 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(UTF16* String, UTF16* StrDelimit);
+
+	/*
+	*
+	capi_StrSplitW - Split a UTF16 string (strings.c)
+	* String [Null-terminated source string to split]
+	* Delimit [Character to be located and replaced]
+	* returns a pointer to the UTF16 string following the Delimit, or 0 if Delimit is not found
+	* When Delimit is found its set to 0
+	*
+	*/
+	CAPI_FUNC(UTF16*) capi_StrSplitW(UTF16* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrReverseW - Reverse a UTF16 string (strings.c)
+	* String [Null-terminated source string to reverse]
+	*
+	*/
+	CAPI_FUNC(void) capi_StrReverseW(UTF16* String);
+
+	/*
+	*
+	capi_StrLenL - Get the length of a UTF32 string (strings.c)
+	* String [Pointer to a null-terminated string]
+	* returns the number of characters in the string, not including the terminating null character
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrLenL(UTF32* String);
+
+	/*
+	*
+	capi_StrCopyL - Copy a UTF32 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF32 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF32 units copied to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, UTF32* Source);
+
+	/*
+	*
+	capi_StrAppendL - Appends a UTF32 string (strings.c)
+	* Destination [Null-terminated destination string buffer]
+	* Length [Length of the destination string buffer in UTF32 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of UTF32 units appended to the destination string, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, UTF32* Source);
+
+	/*
+	*
+	capi_StrCompareL - Compare UTF32 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareL(UTF32* String1, UTF32* String2);
+
+	/*
+	*
+	capi_StrCompareInsensitiveL - Perform a case-insensitive comparison of UTF32 strings (strings.c)
+	* String1 [Null-terminated string to compare]
+	* String2 [Null-terminated string to compare]
+	* The return value indicates the ordinal relation of String1 to String2
+	*	< 0  String1 is less than String2
+	*	  0  String1 is identical to String2
+	*	> 0  String1 is greater than String2
+	* 0x7FFFFFFF is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveL(UTF32* String1, UTF32* String2);
+
+	/*
+	*
+	capi_StrFindL - Find a character in a UTF32 string (strings.c)
+	* String [Null-terminated source string to search]
+	* Delimit [Character to be located]
+	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF32*) capi_StrFindL(UTF32* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrFindStrL - Find a UTF32 string in a UTF32 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit);
+
+	/*
+	*
+	capi_StrFindStrInsensitiveL - Perform a case-insensitive search for a UTF32 string in a UTF32 string (strings.c)
+	* String [Null-terminated source string to search]
+	* StrDelimit [String to be located]
+	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	*
+	*/
+	CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(UTF32* String, UTF32* StrDelimit);
+
+	/*
+	*
+	capi_StrSplitL - Split a UTF32 string (strings.c)
+	* String [Null-terminated source string to split]
+	* Delimit [Character to be located and replaced]
+	* returns a pointer to the UTF32 string following the Delimit, or 0 if Delimit is not found
+	* When Delimit is found its set to 0
+	*
+	*/
+	CAPI_FUNC(UTF32*) capi_StrSplitL(UTF32* String, U32 Delimit);
+
+	/*
+	*
+	capi_StrReverseL - Reverse a UTF32 string (strings.c)
+	* String [Null-terminated source string to reverse]
+	*
+	*/
+	CAPI_FUNC(void) capi_StrReverseL(UTF32* String);
+
+	/*
+	*
+	capi_UTF8_To_UTF16 - Convert a UTF8 string to a UTF16 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF16 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF16 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, UTF8* Source);
+
+	/*
+	*
+	capi_UTF8_To_UTF32 - Convert a UTF8 string to a UTF32 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF32 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF32 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, UTF8* Source);
+
+	/*
+	*
+	capi_UTF16_To_UTF8 - Convert a UTF16 string to a UTF8 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF8 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF8 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, UTF16* Source);
+
+	/*
+	*
+	capi_UTF16_To_UTF32 - Convert a UTF16 string to a UTF32 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF32 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF32 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, UTF16* Source);
+
+	/*
+	*
+	capi_UTF32_To_UTF8 - Convert a UTF32 string to a UTF8 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF8 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF8 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, UTF32* Source);
+
+	/*
+	*
+	capi_UTF32_To_UTF16 - Convert a UTF32 string to a UTF16 string (strings.c)
+	* Destination [Pointer to the destination string buffer]
+	* Length [Length of the destination string buffer in UTF16 units]
+	* Source [Null-terminated source string buffer]
+	* returns the number of characters converted to UTF16 and put into the Destination buffer, not including the terminating null character
+	* If there is no null terminator within Length, then Length is returned to indicate the error condition
+	* -1 is returned for an invalid parameter
+	*
+	*/
+	CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, UTF32* Source);
 
 #ifdef __cplusplus
 }

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -255,7 +255,7 @@ PNG_PARAMETERS
 Z_NO_COMPRESSION, Z_BEST_SPEED, Z_BEST_COMPRESSION, Z_DEFAULT_COMPRESSION
 * FilterMethod [The filter method] 0 = filter method 0
 * InterlaceMethod [The interlace method] 0 = interlace method 0 (null method), 1 = interlace method 1 (Adam7 method)
-* IDAT_Length [The maximum size in bytes of the IDAT chunks] Values 0x20000 (128 KB) or 0x80000 (512 KB) are recommended
+* IDAT_Size [The maximum size in bytes of the IDAT chunks] Values 0x20000 (128 KB) or 0x80000 (512 KB) are recommended
 *
 */
 STRUCT(PNG_PARAMETERS)
@@ -264,7 +264,7 @@ STRUCT(PNG_PARAMETERS)
 	int Level;
 	U8 FilterMethod;
 	U8 InterlaceMethod;
-	U32 IDAT_Length;
+	U32 IDAT_Size;
 };
 
 #ifdef __cplusplus
@@ -706,7 +706,7 @@ extern "C" {
 	* returns CAPI_ERROR_NONE on success
 	*
 	*/
-	CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize, IMAGE* pImage);
+	CAPI_FUNC(I32) capi_Create_BMP_ToMemory(BMP** ppFilePointer, U64* pFileSize, IMAGE* pImage);
 
 	/*
 	*
@@ -718,7 +718,7 @@ extern "C" {
 	* returns CAPI_ERROR_NONE on success
 	*
 	*/
-	CAPI_FUNC(I32) capi_Create_JPG_ImageToMemory(JPG** ppFilePointer, U64* pFileSize, IMAGE* pImage, U8 Quality);
+	CAPI_FUNC(I32) capi_Create_JPG_ToMemory(JPG** ppFilePointer, U64* pFileSize, IMAGE* pImage, U8 Quality);
 
 	/*
 	*
@@ -730,7 +730,7 @@ extern "C" {
 	* returns CAPI_ERROR_NONE on success
 	*
 	*/
-	CAPI_FUNC(I32) capi_Create_PNG_ImageToMemory(PNG** ppFilePointer, U64* pFileSize, IMAGE* pImage, PNG_PARAMETERS* pParameters);
+	CAPI_FUNC(I32) capi_Create_PNG_ToMemory(PNG** ppFilePointer, U64* pFileSize, IMAGE* pImage, PNG_PARAMETERS* pParameters);
 
 	/*
 	*
@@ -744,7 +744,7 @@ extern "C" {
 	* returns CAPI_ERROR_NONE on success
 	*
 	*/
-	CAPI_FUNC(I32) capi_Create_ICO_ImageToMemory(ICO** ppFilePointer, U64* pFileSize, IMAGE* pImageList, U16 nImages, U8 Format, void* pParameters);
+	CAPI_FUNC(I32) capi_Create_ICO_ToMemory(ICO** ppFilePointer, U64* pFileSize, IMAGE* pImageList, U16 nImages, U8 Format, void* pParameters);
 
 #ifdef __cplusplus
 }

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -136,11 +136,33 @@ typedef UTF16 STRING;
 #define STR(String) L##String
 #define capi_Version capi_VersionW
 #define capi_ErrorCodeToString capi_ErrorCodeToStringW
+#define capi_StrLen capi_StrLenW
+#define capi_StrUnits capi_StrUnitsW
+#define capi_StrCopy capi_StrCopyW
+#define capi_StrAppend capi_StrAppendW
+#define capi_StrCompare capi_StrCompareW
+#define capi_StrCompareInsensitive capi_StrCompareInsensitiveW
+#define capi_StrFind capi_StrFindW
+#define capi_StrFindStr capi_StrFindStrW
+#define capi_StrFindStrInsensitive capi_StrFindStrInsensitiveW
+#define capi_StrSplit capi_StrSplitW
+#define capi_StrReverse capi_StrReverseW
 #else
 typedef UTF8 STRING;
 #define STR(String) String
 #define capi_Version capi_VersionA
 #define capi_ErrorCodeToString capi_ErrorCodeToStringA
+#define capi_StrLen capi_StrLenU
+#define capi_StrUnits capi_StrUnitsU
+#define capi_StrCopy capi_StrCopyU
+#define capi_StrAppend capi_StrAppendU
+#define capi_StrCompare capi_StrCompareU
+#define capi_StrCompareInsensitive capi_StrCompareInsensitiveU
+#define capi_StrFind capi_StrFindU
+#define capi_StrFindStr capi_StrFindStrU
+#define capi_StrFindStrInsensitive capi_StrFindStrInsensitiveU
+#define capi_StrSplit capi_StrSplitU
+#define capi_StrReverse capi_StrReverseU
 #endif
 
 /* MACROS FOR READING BIG ENDIAN & LITTLE ENDIAN */
@@ -1400,6 +1422,701 @@ extern "C" {
 
 #ifdef __cplusplus
 }
+#endif
+
+#ifdef __cplusplus
+struct String
+{
+	//  Get the length of a string
+	//      String [Pointer to a null-terminated string]
+	//  returns the number of characters in the string, not including the terminating null character
+	//  -1 is returned for an invalid parameter
+	static size_t Length(const STRING* String)
+	{
+		return capi_StrLen(String);
+	}
+
+	//  Get the number of units in a string
+	//      String [Pointer to a null-terminated string]
+	//  returns the number of units in the string, not including the terminating null character
+	//  -1 is returned for an invalid parameter
+	//  To get the size of the string in bytes, multiply the result by sizeof(STRING)
+	static size_t Units(const STRING* String)
+	{
+		return capi_StrUnits(String);
+	}
+
+	//  Copy a string
+	//      Destination [Pointer to the destination string buffer]
+	//      Length [Length of the destination string buffer in units]
+	//      Source [Null-terminated source string buffer]
+	//  returns the number of units copied to the destination string, not including the terminating null character
+	//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+	//  -1 is returned for an invalid parameter
+	static size_t Copy(STRING* Destination, size_t Length, const STRING* Source)
+	{
+		return capi_StrCopy(Destination, Length, Source);
+	}
+
+	//  Append a string
+	//      Destination [Null-terminated destination string buffer]
+	//      Length [Length of the destination string buffer in units]
+	//      Source [Null-terminated source string buffer]
+	//  returns the number of units appended to the destination string, not including the terminating null character
+	//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+	//  -1 is returned for an invalid parameter
+	static size_t Append(STRING* Destination, size_t Length, const STRING* Source)
+	{
+		return capi_StrAppend(Destination, Length, Source);
+	}
+
+	//  Compare strings
+	//      String1 [Null-terminated string to compare]
+	//      String2 [Null-terminated string to compare]
+	//  The return value indicates the ordinal relation of String1 to String2
+	//      < 0  String1 is less than String2
+	//        0  String1 is identical to String2
+	//      > 0  String1 is greater than String2
+	//  0x7FFFFFFF is returned for an invalid parameter
+	static I32 Compare(const STRING* String1, const STRING* String2)
+	{
+		return capi_StrCompare(String1, String2);
+	}
+
+	//  Perform a case-insensitive comparison of strings
+	//      String1 [Null-terminated string to compare]
+	//      String2 [Null-terminated string to compare]
+	//  The return value indicates the ordinal relation of String1 to String2
+	//      < 0  String1 is less than String2
+	//        0  String1 is identical to String2
+	//      > 0  String1 is greater than String2
+	//  0x7FFFFFFF is returned for an invalid parameter
+	static I32 CompareInsensitive(const STRING* String1, const STRING* String2)
+	{
+		return capi_StrCompareInsensitive(String1, String2);
+	}
+
+	//  Find a character in a string
+	//      String [Null-terminated source string to search]
+	//      Delimit [Character to be located]
+	//  returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+	static STRING* Find(const STRING* String, STRING Delimit)
+	{
+		return capi_StrFind(String, Delimit);
+	}
+
+	//  Find a string in a string
+	//      String [Null-terminated source string to search]
+	//      StrDelimit [String to be located]
+	//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	static STRING* FindStr(const STRING* String, const STRING* StrDelimit)
+	{
+		return capi_StrFindStr(String, StrDelimit);
+	}
+
+	//  Perform a case-insensitive search for a string in a string
+	//      String [Null-terminated source string to search]
+	//      StrDelimit [String to be located]
+	//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+	static STRING* FindStrInsensitive(const STRING* String, const STRING* StrDelimit)
+	{
+		return capi_StrFindStrInsensitive(String, StrDelimit);
+	}
+
+	//  Split a string
+	//      String [Null-terminated source string to split]
+	//      Delimit [Character to be located and replaced]
+	//  returns a pointer to the string following the Delimit, or 0 if Delimit is not found
+	//  When Delimit is found its set to 0
+	static STRING* Split(STRING* String, STRING Delimit)
+	{
+		return capi_StrSplit(String, Delimit);
+	}
+
+	//  Reverse a string
+	//      String [Null-terminated source string to reverse]
+	static void Reverse(STRING* String)
+	{
+		capi_StrReverse(String);
+	}
+
+	struct Encoding
+	{
+		struct _ASCII_
+		{
+			//  Get the length of a ASCII string
+			//      String [Pointer to a null-terminated string]
+			//  returns the number of characters in the string, not including the terminating null character
+			//  -1 is returned for an invalid parameter
+			//  To get the size of the string in bytes, multiply the result by sizeof(ASCII)
+			static size_t Length(const ASCII* String)
+			{
+				return capi_StrLenA(String);
+			}
+
+			//  Copy a ASCII string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in ASCII units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units copied to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Copy(ASCII* Destination, size_t Length, const ASCII* Source)
+			{
+				return capi_StrCopyA(Destination, Length, Source);
+			}
+
+			//  Append a ASCII string
+			//      Destination [Null-terminated destination string buffer]
+			//      Length [Length of the destination string buffer in ASCII units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units appended to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Append(ASCII* Destination, size_t Length, const ASCII* Source)
+			{
+				return capi_StrAppendA(Destination, Length, Source);
+			}
+
+			//  Compare ASCII strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 Compare(const ASCII* String1, const ASCII* String2)
+			{
+				return capi_StrCompareA(String1, String2);
+			}
+
+			//  Perform a case-insensitive comparison of ASCII strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 CompareInsensitive(const ASCII* String1, const ASCII* String2)
+			{
+				return capi_StrCompareInsensitiveA(String1, String2);
+			}
+
+			//  Find a character in a ASCII string
+			//      String [Null-terminated source string to search]
+			//      Delimit [Character to be located]
+			//  returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+			static ASCII* Find(const ASCII* String, ASCII Delimit)
+			{
+				return capi_StrFindA(String, Delimit);
+			}
+
+			//  Find a ASCII string in a ASCII string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static ASCII* FindStr(const ASCII* String, const ASCII* StrDelimit)
+			{
+				return capi_StrFindStrA(String, StrDelimit);
+			}
+
+			//  Perform a case-insensitive search for a ASCII string in a ASCII string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static ASCII* FindStrInsensitive(const ASCII* String, const ASCII* StrDelimit)
+			{
+				return capi_StrFindStrInsensitiveA(String, StrDelimit);
+			}
+
+			//  Split a ASCII string
+			//      String [Null-terminated source string to split]
+			//      Delimit [Character to be located and replaced]
+			//  returns a pointer to the string following the Delimit, or 0 if Delimit is not found
+			//  When Delimit is found its set to 0
+			static ASCII* Split(ASCII* String, ASCII Delimit)
+			{
+				return capi_StrSplitA(String, Delimit);
+			}
+
+			//  Reverse a ASCII string
+			//      String [Null-terminated source string to reverse]
+			static void Reverse(ASCII* String)
+			{
+				capi_StrReverseA(String);
+			}
+		};
+		struct _UTF8_
+		{
+			//  Get the number of bytes (units) a UTF8 code-point encoding uses
+			//      Code [The 1st UTF8 unit of the code-point encoding]
+			//  returns the number of UTF8 units the code-point encoding uses, or 0 for an error
+			static U8 GetCharUnits(UTF8 Code)
+			{
+				return capi_UTF8_GetCharUnits(Code);
+			}
+
+			//  Encode a code-point using the UTF8 encoding
+			//      String [The destination string buffer]
+			//      CodePoint [The code-point to encode]
+			//  returns the number of UTF8 units that was written to String, or 0 for an error
+			//  This function does not check if String is valid and does not output any null-terminator character
+			//  Consider using the safer version String::Encoding::_UTF8_::Encode
+			static U8 Encode_Unsafe(UTF8* String, U32 CodePoint)
+			{
+				return capi_UTF8_Encode_Unsafe(String, CodePoint);
+			}
+
+			//  Encode a code-point using the UTF8 encoding
+			//      String [The destination string buffer]
+			//      Length [Length of the destination string buffer in UTF8 units]
+			//      CodePoint [The code-point to encode]
+			//  returns the number of UTF8 units that was written to String, not including the terminating null character, or 0 for an error
+			//  This function does not check if String is valid
+			static U8 Encode(UTF8* String, size_t Length, U32 CodePoint)
+			{
+				return capi_UTF8_Encode(String, Length, CodePoint);
+			}
+
+			//  Decode a UTF8 encoding into a code-point
+			//      Units [The number of UTF8 units the code-point uses] use String::Encoding::_UTF8_::GetCharUnits to get this value
+			//      String [The source string to decode a code-point from]
+			//  returns the decoded code-point, or 0 for an error
+			//  This function does not check if String is valid
+			static U32 Decode(U8 Units, const UTF8* String)
+			{
+				return capi_UTF8_Decode(Units, String);
+			}
+
+			//  Get the length of a UTF8 string
+			//      String [Pointer to a null-terminated string]
+			//  returns the number of characters in the string, not including the terminating null character
+			//  -1 is returned for an invalid parameter
+			static size_t Length(const UTF8* String)
+			{
+				return capi_StrLenU(String);
+			}
+
+			//  Copy a UTF8 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF8 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units copied to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Copy(UTF8* Destination, size_t Length, const UTF8* Source)
+			{
+				return capi_StrCopyU(Destination, Length, Source);
+			}
+
+			//  Append a UTF8 string
+			//      Destination [Null-terminated destination string buffer]
+			//      Length [Length of the destination string buffer in UTF8 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units appended to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Append(UTF8* Destination, size_t Length, const UTF8* Source)
+			{
+				return capi_StrAppendU(Destination, Length, Source);
+			}
+
+			//  Compare UTF8 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 Compare(const UTF8* String1, const UTF8* String2)
+			{
+				return capi_StrCompareU(String1, String2);
+			}
+
+			//  Perform a case-insensitive comparison of UTF8 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 CompareInsensitive(const UTF8* String1, const UTF8* String2)
+			{
+				return capi_StrCompareInsensitiveU(String1, String2);
+			}
+
+			//  Find a character in a UTF8 string
+			//      String [Null-terminated source string to search]
+			//      Delimit [Character to be located]
+			//  returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+			static UTF8* Find(const UTF8* String, UTF8 Delimit)
+			{
+				return capi_StrFindU(String, Delimit);
+			}
+
+			//  Find a UTF8 string in a UTF8 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF8* FindStr(const UTF8* String, const UTF8* StrDelimit)
+			{
+				return capi_StrFindStrU(String, StrDelimit);
+			}
+
+			//  Perform a case-insensitive search for a UTF8 string in a UTF8 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF8* FindStrInsensitive(const UTF8* String, const UTF8* StrDelimit)
+			{
+				return capi_StrFindStrInsensitiveU(String, StrDelimit);
+			}
+
+			//  Split a UTF8 string
+			//      String [Null-terminated source string to split]
+			//      Delimit [Character to be located and replaced]
+			//  returns a pointer to the string following the Delimit, or 0 if Delimit is not found
+			//  When Delimit is found its set to 0
+			static UTF8* Split(UTF8* String, UTF8 Delimit)
+			{
+				return capi_StrSplitU(String, Delimit);
+			}
+
+			//  Reverse a UTF8 string
+			//      String [Null-terminated source string to reverse]
+			static void Reverse(UTF8* String)
+			{
+				capi_StrReverseU(String);
+			}
+
+			//  Convert a UTF8 string to a UTF16 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF16 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF16 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF16(UTF16* Destination, size_t Length, const UTF8* Source)
+			{
+				return capi_UTF8_To_UTF16(Destination, Length, Source);
+			}
+
+			//  Convert a UTF8 string to a UTF32 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF32 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF32 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF32(UTF32* Destination, size_t Length, const UTF8* Source)
+			{
+				return capi_UTF8_To_UTF32(Destination, Length, Source);
+			}
+		};
+		struct _UTF16_
+		{
+			//  Get the number of words (units) a UTF16 code-point encoding uses
+			//      Code [The 1st UTF16 unit of the code-point encoding]
+			//  returns the number of UTF16 units the code-point encoding uses, or 0 for an error
+			static U8 GetCharUnits(UTF16 Code)
+			{
+				return capi_UTF16_GetCharUnits(Code);
+			}
+
+			//  Encode a code-point using the UTF16 encoding
+			//      String [The destination string buffer]
+			//      CodePoint [The code-point to encode]
+			//  returns the number of UTF16 units that was written to String, or 0 for an error
+			//  This function does not check if String is valid and does not output any null-terminator character
+			//  Consider using the safer version String::Encoding::_UTF16_::Encode
+			static U8 Encode_Unsafe(UTF16* String, U32 CodePoint)
+			{
+				return capi_UTF16_Encode_Unsafe(String, CodePoint);
+			}
+
+			//  Encode a code-point using the UTF16 encoding
+			//      String [The destination string buffer]
+			//      Length [Length of the destination string buffer in UTF16 units]
+			//      CodePoint [The code-point to encode]
+			//  returns the number of UTF16 units that was written to String, not including the terminating null character, or 0 for an error
+			//  This function does not check if String is valid
+			static U8 Encode(UTF16* String, size_t Length, U32 CodePoint)
+			{
+				return capi_UTF16_Encode(String, Length, CodePoint);
+			}
+
+			//  Decode a UTF16 encoding into a code-point
+			//      Units [The number of UTF16 units the code-point uses] use String::Encoding::_UTF8_::GetCharUnits to get this value
+			//      String [The source string to decode a code-point from]
+			//  returns the decoded code-point, or 0 for an error
+			//  This function does not check if String is valid
+			static U32 Decode(U8 Units, const UTF16* String)
+			{
+				return capi_UTF16_Decode(Units, String);
+			}
+
+			//  Get the length of a UTF16 string
+			//      String [Pointer to a null-terminated string]
+			//  returns the number of characters in the string, not including the terminating null character
+			//  -1 is returned for an invalid parameter
+			static size_t Length(const UTF16* String)
+			{
+				return capi_StrLenW(String);
+			}
+
+			//  Copy a UTF16 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF16 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units copied to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Copy(UTF16* Destination, size_t Length, const UTF16* Source)
+			{
+				return capi_StrCopyW(Destination, Length, Source);
+			}
+
+			//  Append a UTF16 string
+			//      Destination [Null-terminated destination string buffer]
+			//      Length [Length of the destination string buffer in UTF16 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units appended to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Append(UTF16* Destination, size_t Length, const UTF16* Source)
+			{
+				return capi_StrAppendW(Destination, Length, Source);
+			}
+
+			//  Compare UTF16 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 Compare(const UTF16* String1, const UTF16* String2)
+			{
+				return capi_StrCompareW(String1, String2);
+			}
+
+			//  Perform a case-insensitive comparison of UTF16 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 CompareInsensitive(const UTF16* String1, const UTF16* String2)
+			{
+				return capi_StrCompareInsensitiveW(String1, String2);
+			}
+
+			//  Find a character in a UTF16 string
+			//      String [Null-terminated source string to search]
+			//      Delimit [Character to be located]
+			//  returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+			static UTF16* Find(const UTF16* String, UTF16 Delimit)
+			{
+				return capi_StrFindW(String, Delimit);
+			}
+
+			//  Find a UTF16 string in a UTF16 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF16* FindStr(const UTF16* String, const UTF16* StrDelimit)
+			{
+				return capi_StrFindStrW(String, StrDelimit);
+			}
+
+			//  Perform a case-insensitive search for a UTF16 string in a UTF16 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF16* FindStrInsensitive(const UTF16* String, const UTF16* StrDelimit)
+			{
+				return capi_StrFindStrInsensitiveW(String, StrDelimit);
+			}
+
+			//  Split a UTF16 string
+			//      String [Null-terminated source string to split]
+			//      Delimit [Character to be located and replaced]
+			//  returns a pointer to the string following the Delimit, or 0 if Delimit is not found
+			//  When Delimit is found its set to 0
+			static UTF16* Split(UTF16* String, UTF16 Delimit)
+			{
+				return capi_StrSplitW(String, Delimit);
+			}
+
+			//  Reverse a UTF16 string
+			//      String [Null-terminated source string to reverse]
+			static void Reverse(UTF16* String)
+			{
+				capi_StrReverseW(String);
+			}
+
+			//  Convert a UTF16 string to a UTF8 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF8 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF8 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF8(UTF8* Destination, size_t Length, const UTF16* Source)
+			{
+				return capi_UTF16_To_UTF8(Destination, Length, Source);
+			}
+
+			//  Convert a UTF16 string to a UTF32 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF32 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF32 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF32(UTF32* Destination, size_t Length, const UTF16* Source)
+			{
+				return capi_UTF16_To_UTF32(Destination, Length, Source);
+			}
+		};
+		struct _UTF32_
+		{
+			//  Get the length of a UTF32 string
+			//      String [Pointer to a null-terminated string]
+			//  returns the number of characters in the string, not including the terminating null character
+			//  -1 is returned for an invalid parameter
+			static size_t Length(const UTF32* String)
+			{
+				return capi_StrLenL(String);
+			}
+
+			//  Copy a UTF32 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF32 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units copied to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Copy(UTF32* Destination, size_t Length, const UTF32* Source)
+			{
+				return capi_StrCopyL(Destination, Length, Source);
+			}
+
+			//  Append a UTF32 string
+			//      Destination [Null-terminated destination string buffer]
+			//      Length [Length of the destination string buffer in UTF32 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of units appended to the destination string, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t Append(UTF32* Destination, size_t Length, const UTF32* Source)
+			{
+				return capi_StrAppendL(Destination, Length, Source);
+			}
+
+			//  Compare UTF32 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 Compare(const UTF32* String1, const UTF32* String2)
+			{
+				return capi_StrCompareL(String1, String2);
+			}
+
+			//  Perform a case-insensitive comparison of UTF32 strings
+			//      String1 [Null-terminated string to compare]
+			//      String2 [Null-terminated string to compare]
+			//  The return value indicates the ordinal relation of String1 to String2
+			//      < 0  String1 is less than String2
+			//        0  String1 is identical to String2
+			//      > 0  String1 is greater than String2
+			//  0x7FFFFFFF is returned for an invalid parameter
+			static I32 CompareInsensitive(const UTF32* String1, const UTF32* String2)
+			{
+				return capi_StrCompareInsensitiveL(String1, String2);
+			}
+
+			//  Find a character in a UTF32 string
+			//      String [Null-terminated source string to search]
+			//      Delimit [Character to be located]
+			//  returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
+			static UTF32* Find(const UTF32* String, UTF32 Delimit)
+			{
+				return capi_StrFindL(String, Delimit);
+			}
+
+			//  Find a UTF32 string in a UTF32 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF32* FindStr(const UTF32* String, const UTF32* StrDelimit)
+			{
+				return capi_StrFindStrL(String, StrDelimit);
+			}
+
+			//  Perform a case-insensitive search for a UTF32 string in a UTF32 string
+			//      String [Null-terminated source string to search]
+			//      StrDelimit [String to be located]
+			//  returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
+			static UTF32* FindStrInsensitive(const UTF32* String, const UTF32* StrDelimit)
+			{
+				return capi_StrFindStrInsensitiveL(String, StrDelimit);
+			}
+
+			//  Split a UTF32 string
+			//      String [Null-terminated source string to split]
+			//      Delimit [Character to be located and replaced]
+			//  returns a pointer to the string following the Delimit, or 0 if Delimit is not found
+			//  When Delimit is found its set to 0
+			static UTF32* Split(UTF32* String, UTF32 Delimit)
+			{
+				return capi_StrSplitL(String, Delimit);
+			}
+
+			//  Reverse a UTF32 string
+			//      String [Null-terminated source string to reverse]
+			static void Reverse(UTF32* String)
+			{
+				capi_StrReverseL(String);
+			}
+
+			//  Convert a UTF32 string to a UTF8 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF8 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF8 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF8(UTF8* Destination, size_t Length, const UTF32* Source)
+			{
+				return capi_UTF32_To_UTF8(Destination, Length, Source);
+			}
+
+			//  Convert a UTF32 string to a UTF16 string
+			//      Destination [Pointer to the destination string buffer]
+			//      Length [Length of the destination string buffer in UTF16 units]
+			//      Source [Null-terminated source string buffer]
+			//  returns the number of characters converted to UTF16 and put into the Destination buffer, not including the terminating null character
+			//  If there is no null terminator within Length, then Length is returned to indicate the error condition
+			//  -1 is returned for an invalid parameter
+			static size_t To_UTF16(UTF16* Destination, size_t Length, const UTF32* Source)
+			{
+				return capi_UTF32_To_UTF16(Destination, Length, Source);
+			}
+		};
+	};
+};
 #endif
 
 #endif /* CAPI_H */

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -118,8 +118,8 @@ typedef signed long long I64;
 PACK(STRUCT(I128) { U64 Lo; I64 Hi; });
 PACK(STRUCT(I256) { U128 Lo; I128 Hi; });
 
-typedef I8 ASCII;   // ASCII Unit
-typedef U8 UTF8;    // UTF8 Unit
+typedef char ASCII;   // ASCII Unit
+typedef char UTF8;    // UTF8 Unit
 #ifdef _MSC_VER
 typedef wchar_t UTF16;  // UTF16 Unit
 #else
@@ -767,7 +767,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrLenA(ASCII* String);
+	CAPI_FUNC(size_t) capi_StrLenA(const ASCII* String);
 
 	/*
 	*
@@ -780,7 +780,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, ASCII* Source);
+	CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, const ASCII* Source);
 
 	/*
 	*
@@ -793,7 +793,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, ASCII* Source);
+	CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, const ASCII* Source);
 
 	/*
 	*
@@ -807,7 +807,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareA(ASCII* String1, ASCII* String2);
+	CAPI_FUNC(I32) capi_StrCompareA(const ASCII* String1, const ASCII* String2);
 
 	/*
 	*
@@ -821,7 +821,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareInsensitiveA(ASCII* String1, ASCII* String2);
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveA(const ASCII* String1, const ASCII* String2);
 
 	/*
 	*
@@ -831,7 +831,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
 	*
 	*/
-	CAPI_FUNC(ASCII*) capi_StrFindA(ASCII* String, ASCII Delimit);
+	CAPI_FUNC(ASCII*) capi_StrFindA(const ASCII* String, ASCII Delimit);
 
 	/*
 	*
@@ -841,7 +841,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit);
+	CAPI_FUNC(ASCII*) capi_StrFindStrA(const ASCII* String, const ASCII* StrDelimit);
 
 	/*
 	*
@@ -851,7 +851,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(ASCII* String, ASCII* StrDelimit);
+	CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(const ASCII* String, const ASCII* StrDelimit);
 
 	/*
 	*
@@ -914,7 +914,7 @@ extern "C" {
 	* This function does not check if String is valid
 	*
 	*/
-	CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, UTF8* String);
+	CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, const UTF8* String);
 
 	/*
 	*
@@ -924,7 +924,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrLenU(UTF8* String);
+	CAPI_FUNC(size_t) capi_StrLenU(const UTF8* String);
 
 	/*
 	*
@@ -934,7 +934,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrUnitsU(UTF8* String);
+	CAPI_FUNC(size_t) capi_StrUnitsU(const UTF8* String);
 
 	/*
 	*
@@ -947,7 +947,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, UTF8* Source);
+	CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, const UTF8* Source);
 
 	/*
 	*
@@ -960,7 +960,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, UTF8* Source);
+	CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, const UTF8* Source);
 
 	/*
 	*
@@ -974,7 +974,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareU(UTF8* String1, UTF8* String2);
+	CAPI_FUNC(I32) capi_StrCompareU(const UTF8* String1, const UTF8* String2);
 
 	/*
 	*
@@ -988,7 +988,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareInsensitiveU(UTF8* String1, UTF8* String2);
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveU(const UTF8* String1, const UTF8* String2);
 
 	/*
 	*
@@ -998,7 +998,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF8*) capi_StrFindU(UTF8* String, U32 Delimit);
+	CAPI_FUNC(UTF8*) capi_StrFindU(const UTF8* String, U32 Delimit);
 
 	/*
 	*
@@ -1008,7 +1008,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit);
+	CAPI_FUNC(UTF8*) capi_StrFindStrU(const UTF8* String, const UTF8* StrDelimit);
 
 	/*
 	*
@@ -1018,7 +1018,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(UTF8* String, UTF8* StrDelimit);
+	CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(const UTF8* String, const UTF8* StrDelimit);
 
 	/*
 	*
@@ -1081,7 +1081,7 @@ extern "C" {
 	* This function does not check if String is valid
 	*
 	*/
-	CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, UTF16* String);
+	CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, const UTF16* String);
 
 	/*
 	*
@@ -1091,7 +1091,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrLenW(UTF16* String);
+	CAPI_FUNC(size_t) capi_StrLenW(const UTF16* String);
 
 	/*
 	*
@@ -1102,7 +1102,7 @@ extern "C" {
 	* To get the size of the string in bytes, multiply the result by sizeof(UTF16)
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrUnitsW(UTF16* String);
+	CAPI_FUNC(size_t) capi_StrUnitsW(const UTF16* String);
 
 	/*
 	*
@@ -1115,7 +1115,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, UTF16* Source);
+	CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, const UTF16* Source);
 
 	/*
 	*
@@ -1128,7 +1128,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, UTF16* Source);
+	CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, const UTF16* Source);
 
 	/*
 	*
@@ -1142,7 +1142,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareW(UTF16* String1, UTF16* String2);
+	CAPI_FUNC(I32) capi_StrCompareW(const UTF16* String1, const UTF16* String2);
 
 	/*
 	*
@@ -1156,7 +1156,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareInsensitiveW(UTF16* String1, UTF16* String2);
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveW(const UTF16* String1, const UTF16* String2);
 
 	/*
 	*
@@ -1166,7 +1166,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF16*) capi_StrFindW(UTF16* String, U32 Delimit);
+	CAPI_FUNC(UTF16*) capi_StrFindW(const UTF16* String, U32 Delimit);
 
 	/*
 	*
@@ -1176,7 +1176,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit);
+	CAPI_FUNC(UTF16*) capi_StrFindStrW(const UTF16* String, const UTF16* StrDelimit);
 
 	/*
 	*
@@ -1186,7 +1186,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(UTF16* String, UTF16* StrDelimit);
+	CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(const UTF16* String, const UTF16* StrDelimit);
 
 	/*
 	*
@@ -1215,7 +1215,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrLenL(UTF32* String);
+	CAPI_FUNC(size_t) capi_StrLenL(const UTF32* String);
 
 	/*
 	*
@@ -1228,7 +1228,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, UTF32* Source);
+	CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, const UTF32* Source);
 
 	/*
 	*
@@ -1241,7 +1241,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, UTF32* Source);
+	CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, const UTF32* Source);
 
 	/*
 	*
@@ -1255,7 +1255,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareL(UTF32* String1, UTF32* String2);
+	CAPI_FUNC(I32) capi_StrCompareL(const UTF32* String1, const UTF32* String2);
 
 	/*
 	*
@@ -1269,7 +1269,7 @@ extern "C" {
 	* 0x7FFFFFFF is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(I32) capi_StrCompareInsensitiveL(UTF32* String1, UTF32* String2);
+	CAPI_FUNC(I32) capi_StrCompareInsensitiveL(const UTF32* String1, const UTF32* String2);
 
 	/*
 	*
@@ -1279,7 +1279,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of Delimit in String, or 0 if Delimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF32*) capi_StrFindL(UTF32* String, U32 Delimit);
+	CAPI_FUNC(UTF32*) capi_StrFindL(const UTF32* String, U32 Delimit);
 
 	/*
 	*
@@ -1289,7 +1289,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit);
+	CAPI_FUNC(UTF32*) capi_StrFindStrL(const UTF32* String, const UTF32* StrDelimit);
 
 	/*
 	*
@@ -1299,7 +1299,7 @@ extern "C" {
 	* returns a pointer to the first occurrence of StrDelimit in String, or 0 if StrDelimit is not found
 	*
 	*/
-	CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(UTF32* String, UTF32* StrDelimit);
+	CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(const UTF32* String, const UTF32* StrDelimit);
 
 	/*
 	*
@@ -1331,7 +1331,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, UTF8* Source);
+	CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, const UTF8* Source);
 
 	/*
 	*
@@ -1344,7 +1344,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, UTF8* Source);
+	CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, const UTF8* Source);
 
 	/*
 	*
@@ -1357,7 +1357,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, UTF16* Source);
+	CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, const UTF16* Source);
 
 	/*
 	*
@@ -1370,7 +1370,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, UTF16* Source);
+	CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, const UTF16* Source);
 
 	/*
 	*
@@ -1383,7 +1383,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, UTF32* Source);
+	CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, const UTF32* Source);
 
 	/*
 	*
@@ -1396,7 +1396,7 @@ extern "C" {
 	* -1 is returned for an invalid parameter
 	*
 	*/
-	CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, UTF32* Source);
+	CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, const UTF32* Source);
 
 #ifdef __cplusplus
 }

--- a/Source/CAPI.h
+++ b/Source/CAPI.h
@@ -699,7 +699,7 @@ extern "C" {
 
 	/*
 	*
-	capi_Create_BMP_ImageToMemory - Create a BMP (bitmap) formatted image to memory (bmp.c)
+	capi_Create_BMP_ToMemory - Create a BMP (bitmap) formatted image to memory (bmp.c)
 	* ppFilePointer [Pointer to a variable to receive the pointer to the file]
 	* pFileSize [Pointer to a variable to receive the size of the file in bytes]
 	* pImage [Pointer to a IMAGE structure to create the new BMP image from]
@@ -710,7 +710,7 @@ extern "C" {
 
 	/*
 	*
-	capi_Create_JPG_ImageToMemory - Create a JPG (jpeg) formatted image to memory (jpg.c)
+	capi_Create_JPG_ToMemory - Create a JPG (jpeg) formatted image to memory (jpg.c)
 	* ppFilePointer [Pointer to a variable to receive the pointer to the file]
 	* pFileSize [Pointer to a variable to receive the size of the file in bytes]
 	* pImage [Pointer to a IMAGE structure to create the new JPG image from]
@@ -722,7 +722,7 @@ extern "C" {
 
 	/*
 	*
-	capi_Create_PNG_ImageToMemory - Create a PNG (Portable Network Graphics) formatted image to memory (png.c)
+	capi_Create_PNG_ToMemory - Create a PNG (Portable Network Graphics) formatted image to memory (png.c)
 	* ppFilePointer [Pointer to a variable to receive the pointer to the file]
 	* pFileSize [Pointer to a variable to receive the size of the file in bytes]
 	* pImage [Pointer to a IMAGE structure to create the new PNG image from]
@@ -734,7 +734,7 @@ extern "C" {
 
 	/*
 	*
-	capi_Create_ICO_ImageToMemory - Create a ICO (icon) formatted image to memory (ico.c)
+	capi_Create_ICO_ToMemory - Create a ICO (icon) formatted image to memory (ico.c)
 	* ppFilePointer [Pointer to a variable to receive the pointer to the file]
 	* pFileSize [Pointer to a variable to receive the size of the file in bytes]
 	* pImageList [Pointer to an array of IMAGE structures to create the new ICO images from]

--- a/Source/bmp.c
+++ b/Source/bmp.c
@@ -719,11 +719,11 @@ CAPI_FUNC(I32) capi_Load_BMP_FromMemory(IMAGE* pImage, U32 Alignment, BMP* pBmpF
 	return CAPI_ERROR_NONE;
 }
 
-CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize, IMAGE* pImage)
+CAPI_FUNC(I32) capi_Create_BMP_ToMemory(BMP** ppFilePointer, U64* pFileSize, IMAGE* pImage)
 {
 	PIXEL* pSource, pPalette[256];
 	size_t Stride;
-	U32 Width, Height, PaletteLen, Length, BPP, ScanLine, X, I;
+	U32 Width, Height, PaletteLen, Size, BPP, ScanLine, X, I;
 	BMP* pBMP; BMPV3* pBMPV3;
 	PIXEL_BGRA* pPaletteBGRA;
 	void* pDestination;
@@ -738,7 +738,7 @@ CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize
 	Width = pImage->Width;
 	Height = pImage->Height;
 
-	Length = sizeof(BMP);
+	Size = sizeof(BMP);
 
 	if (image_get_transparency_level(pImage) > 1)
 	{
@@ -755,7 +755,7 @@ CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize
 		}
 		else
 		{
-			Length += sizeof(PIXEL_BGRA) * PaletteLen;
+			Size += sizeof(PIXEL_BGRA) * PaletteLen;
 
 			if (PaletteLen <= 2) BPP = 1;
 			else if (PaletteLen <= 4) BPP = 2;
@@ -765,20 +765,20 @@ CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize
 	}
 
 	Stride = ((((Width * BPP) + 31) & ~31) >> 3);
-	Length += (U32)Stride * Height;
+	Size += (U32)Stride * Height;
 	pDestination = (void*)((Height - 1) * Stride);
 
 	Stride = -(ptrdiff_t)Stride;
 
-	Length += sizeof(BMPV3);
+	Size += sizeof(BMPV3);
 
-	pBMP = (BMP*)capi_malloc(Length);
+	pBMP = (BMP*)capi_malloc(Size);
 	if (pBMP == 0) return CAPI_ERROR_OUT_OF_MEMORY;
 
 	pBMPV3 = (BMPV3*)((size_t)pBMP + sizeof(BMP));
 
 	pBMP->Type = 0x4D42;
-	pBMP->BmpSize = Length;
+	pBMP->BmpSize = Size;
 	pBMP->Reserved1 = 0;
 	pBMP->Reserved2 = 0;
 	pBMP->PixelStart = sizeof(BMP) + sizeof(BMPV3) + (sizeof(PIXEL_BGRA) * PaletteLen);
@@ -873,7 +873,7 @@ CAPI_FUNC(I32) capi_Create_BMP_ImageToMemory(BMP** ppFilePointer, U64* pFileSize
 	}
 
 	*ppFilePointer = pBMP;
-	*pFileSize = Length;
+	*pFileSize = Size;
 
 	return CAPI_ERROR_NONE;
 }

--- a/Source/example.c
+++ b/Source/example.c
@@ -85,28 +85,28 @@ THREAD_WINDOW* TestApp_GetOpenThreadWindowSlot()
 	return 0;
 }
 
-void* LoadFile(const STRING* FilePath, U64* pFileLength)
+void* LoadFile(const STRING* FilePath, U64* pFileSize)
 {
 	FILE* Stream;
-	size_t BufferLength;
+	size_t BufferSize;
 	void* pThisFile;
 	void* pNewBlock;
 
-	if ((FilePath == 0) || (pFileLength == 0)) return 0;
+	if ((FilePath == 0) || (pFileSize == 0)) return 0;
 
-	*pFileLength = 0;
+	*pFileSize = 0;
 
 	Stream = str_fopen(FilePath, STR("rb"));
 	if (Stream == 0) return 0;
 
 	pThisFile = 0;
-	BufferLength = 0;
+	BufferSize = 0;
 
 	do
 	{
-		BufferLength += 0x1000;
+		BufferSize += 0x1000;
 
-		pNewBlock = capi_realloc(pThisFile, BufferLength);
+		pNewBlock = capi_realloc(pThisFile, BufferSize);
 		if (pNewBlock == 0)
 		{
 			if (pThisFile != 0) capi_free(pThisFile);
@@ -116,7 +116,7 @@ void* LoadFile(const STRING* FilePath, U64* pFileLength)
 
 		pThisFile = pNewBlock;
 
-		*pFileLength += fread(&((U8*)pThisFile)[*pFileLength], 1, 0x1000, Stream);
+		*pFileSize += fread(&((U8*)pThisFile)[*pFileSize], 1, 0x1000, Stream);
 	} while (!(feof(Stream)));
 
 	fclose(Stream);
@@ -124,21 +124,21 @@ void* LoadFile(const STRING* FilePath, U64* pFileLength)
 	return pThisFile;
 }
 
-I32 SaveFile(const STRING* FilePath, void* pFilePointer, U64 FileLength)
+I32 SaveFile(const STRING* FilePath, void* pFilePointer, U64 FileSize)
 {
 	FILE* Stream;
 	size_t nBytesWrite;
 	I32 ErrorCode;
 
-	if ((FilePath == 0) || (pFilePointer == 0) || (FileLength == 0)) return CAPI_ERROR_INVALID_PARAMETER;
+	if ((FilePath == 0) || (pFilePointer == 0) || (FileSize == 0)) return CAPI_ERROR_INVALID_PARAMETER;
 
 	ErrorCode = CAPI_ERROR_NONE;
 
 	Stream = str_fopen(FilePath, STR("w+b"));
 	if (Stream == 0) return CAPI_ERROR_ACCESS_DENIED;
 
-	nBytesWrite = fwrite(pFilePointer, 1, (size_t)FileLength, Stream);
-	if (nBytesWrite != FileLength)
+	nBytesWrite = fwrite(pFilePointer, 1, (size_t)FileSize, Stream);
+	if (nBytesWrite != FileSize)
 	{
 		ErrorCode = CAPI_ERROR_ACCESS_DENIED;
 		goto exit_func;
@@ -159,10 +159,10 @@ void SetupFilePath(STRING* pFilePath, const STRING* pDirectory, const STRING* pF
 void Load_TestImage(TEST_IMAGE_DATA* TestImage, BOOL FailTest)
 {
 	void* pFileData;
-	U64 FileLength;
+	U64 FileSize;
 	I32 ErrorCode;
 
-	pFileData = LoadFile(TestImage->FilePath, &FileLength);
+	pFileData = LoadFile(TestImage->FilePath, &FileSize);
 	if (pFileData == 0)
 	{
 		TestApp_OutMessage(STR("ERROR: LoadFile failed to load "), FALSE);
@@ -172,7 +172,7 @@ void Load_TestImage(TEST_IMAGE_DATA* TestImage, BOOL FailTest)
 
 	if (FailTest == FALSE)
 	{
-		ErrorCode = capi_LoadImageFromMemory(&TestImage->TestImage, IMAGE_DEFAULT_ALIGNMENT, pFileData, FileLength);
+		ErrorCode = capi_LoadImageFromMemory(&TestImage->TestImage, IMAGE_DEFAULT_ALIGNMENT, pFileData, FileSize);
 		if (ErrorCode != CAPI_ERROR_NONE)
 		{
 			TestApp_OutMessage(STR("ERROR: capi_LoadImageFromMemory failed to load "), FALSE);
@@ -181,7 +181,7 @@ void Load_TestImage(TEST_IMAGE_DATA* TestImage, BOOL FailTest)
 	}
 	else
 	{
-		ErrorCode = capi_LoadImageFromMemory(&TestImage->TestImage, IMAGE_DEFAULT_ALIGNMENT, pFileData, FileLength);
+		ErrorCode = capi_LoadImageFromMemory(&TestImage->TestImage, IMAGE_DEFAULT_ALIGNMENT, pFileData, FileSize);
 		if (ErrorCode == CAPI_ERROR_NONE)
 		{
 			TestApp_OutMessage(STR("ERROR: capi_LoadImageFromMemory had a FALSE success with "), FALSE);

--- a/Source/ico.h
+++ b/Source/ico.h
@@ -47,6 +47,6 @@ CAPI_SUBFUNC(U32) ico_get_embedded_image_dimensions_file(FILE* pIcoFile, U32 Ima
 
 CAPI_SUBFUNC(void) ico_apply_icAND(U8* p_icAND_mask, IMAGE* pImage, size_t mask_Stride);
 
-CAPI_SUBFUNC(I32) ico_Create_BMP_Image(BMPV3** ppFilePointer, U64* pFileSize, IMAGE* pImage);
+CAPI_SUBFUNC(I32) ico_Create_BMP_ToMemory(BMPV3** ppFilePointer, U64* pFileSize, IMAGE* pImage);
 
 #endif /* ICO_H */

--- a/Source/jpg.c
+++ b/Source/jpg.c
@@ -202,9 +202,9 @@ jpeg_fatal_error:
 	return ErrorCode;
 }
 
-CAPI_FUNC(I32) capi_Create_JPG_ImageToMemory(JPG** ppFilePointer, U64* pFileSize, IMAGE* pImage, U8 Quality)
+CAPI_FUNC(I32) capi_Create_JPG_ToMemory(JPG** ppFilePointer, U64* pFileSize, IMAGE* pImage, U8 Quality)
 {
-	size_t Length;
+	size_t Size;
 	U32 Width, Height, ScanLine, I;
 	JSAMPROW row_pointer[1];
 	PIXEL_RGB* pImageBuffer;
@@ -232,9 +232,9 @@ CAPI_FUNC(I32) capi_Create_JPG_ImageToMemory(JPG** ppFilePointer, U64* pFileSize
 	jpeg_create_compress(&cinfo);
 
 	pJPG = 0;
-	Length = 0;
+	Size = 0;
 
-	jpeg_mem_dest(&cinfo, (U8**)&pJPG, (size_t*)&Length);
+	jpeg_mem_dest(&cinfo, (U8**)&pJPG, (size_t*)&Size);
 
 	cinfo.image_width = Width;
 	cinfo.image_height = Height;
@@ -266,7 +266,7 @@ CAPI_FUNC(I32) capi_Create_JPG_ImageToMemory(JPG** ppFilePointer, U64* pFileSize
 	capi_free(pImageBuffer);
 
 	*ppFilePointer = pJPG;
-	*pFileSize = Length;
+	*pFileSize = Size;
 
 	return CAPI_ERROR_NONE;
 }

--- a/Source/strings.c
+++ b/Source/strings.c
@@ -1,0 +1,1565 @@
+
+/******************************************************************************************
+*
+* Name: strings.c
+*
+* Created by  Brian Sullender
+*
+* Description:
+*  This file defines the basic and common string functions.
+*
+*******************************************************************************************/
+
+#include "CAPI.h"
+
+// *                      * //
+// **                    ** //
+// ***  ASCII versions  *** //
+// **                    ** //
+// *                      * //
+
+CAPI_FUNC(size_t) capi_StrLenA(ASCII* String)
+{
+	size_t Len;
+
+	if (String == 0) return -1;
+	Len = 0;
+
+	while (*String != 0)
+	{
+		Len++;
+		String++;
+	}
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, ASCII* Source)
+{
+	size_t Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	Length--;
+	while (*Source != 0)
+	{
+		if (Len == Length)
+		{
+			Destination[Len] = 0;
+			return Length + 1;
+		}
+		Destination[Len] = *Source;
+		Len++;
+		Source++;
+	}
+	Destination[Len] = 0;
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, ASCII* Source)
+{
+	size_t Len, I, cnt;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	Length--;
+	while (Destination[Len] != 0)
+	{
+		if (Len == Length) return Length + 1;
+		Len++;
+	}
+	cnt = Len;
+
+	I = 0;
+	while (Source[I] != 0)
+	{
+		if (Len == Length)
+		{
+			Destination[Len] = 0;
+			return Length + 1;
+		}
+		Destination[Len] = Source[I];
+		Len++;
+		I++;
+	}
+	Destination[Len] = 0;
+
+	return Len - cnt;
+}
+
+CAPI_FUNC(I32) capi_StrCompareA(ASCII* String1, ASCII* String2)
+{
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		if (*String1 != *String2)
+		{
+			if (*String1 > *String2) return 1;
+			else return -1;
+		}
+		String1++;
+		String2++;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(I32) capi_StrCompareInsensitiveA(ASCII* String1, ASCII* String2)
+{
+	ASCII Code1, Code2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		Code1 = *String1;
+		Code2 = *String2;
+
+		if ((Code1 > 0x40) && (Code1 < 0x5B)) Code1 += 0x20;
+		if ((Code2 > 0x40) && (Code2 < 0x5B)) Code2 += 0x20;
+
+		if (Code1 != Code2)
+		{
+			if (Code1 > Code2) return 1;
+			else return -1;
+		}
+		String1++;
+		String2++;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(ASCII*) capi_StrFindA(ASCII* String, ASCII Delimit)
+{
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		if (*String == Delimit) return String;
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit)
+{
+	size_t I, Length;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenA(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		while ((String[I] != 0) && (StrDelimit[I] != 0))
+		{
+			if (String[I] != StrDelimit[I]) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(ASCII* String, ASCII* StrDelimit)
+{
+	size_t I, Length;
+	ASCII Code1, Code2;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenA(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		while ((String[I] != 0) && (StrDelimit[I] != 0))
+		{
+			Code1 = String[I];
+			Code2 = StrDelimit[I];
+
+			if ((Code1 > 0x40) && (Code1 < 0x5B)) Code1 += 0x20;
+			if ((Code2 > 0x40) && (Code2 < 0x5B)) Code2 += 0x20;
+
+			if (Code1 != Code2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(ASCII*) capi_StrSplitA(ASCII* String, ASCII Delimit)
+{
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		if (*String == Delimit)
+		{
+			*String = 0;
+			return String + 1;
+		}
+		String = String + 1;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(void) capi_StrReverseA(ASCII* String)
+{
+	ASCII Code;
+	ASCII* First, * Last;
+
+	if (String == 0) return;
+
+	Last = First = String;
+
+	while (*Last != 0) Last++;
+	while ((First != Last) && (First != --Last))
+	{
+		Code = *First;
+		*First = *Last;
+		*Last = Code;
+		First = First + 1;
+	}
+}
+
+// *                         * //
+// **                       ** //
+// ***  UTF-8LE  versions  *** //
+// **                       ** //
+// *                         * //
+
+CAPI_FUNC(U8) capi_UTF8_GetCharUnits(UTF8 Code)
+{
+	if ((Code & 0x80) == 0) return 1;
+	else if ((Code & 0xE0) == 0xC0) return 2;
+	else if ((Code & 0xF0) == 0xE0) return 3;
+	else if ((Code & 0xF8) == 0xF0) return 4;
+	else return 0;
+}
+
+CAPI_FUNC(U8) capi_UTF8_Encode_Unsafe(UTF8* String, U32 CodePoint)
+{
+	if (CodePoint == 0) return 0;
+
+	if (CodePoint < 0x80)
+	{
+		String[0] = (UTF8)CodePoint & 0x7F;
+		return 1;
+	}
+	else if (CodePoint < 0x800)
+	{
+		String[0] = (UTF8)(CodePoint >> 6) | 0xC0;
+		String[1] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		return 2;
+	}
+	else if (CodePoint < 0x10000)
+	{
+		String[0] = (UTF8)(CodePoint >> 12) | 0xE0;
+		String[1] = (UTF8)((CodePoint >> 6) & 0x3F) | 0x80;
+		String[2] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		return 3;
+	}
+	else if (CodePoint < 0x110000)
+	{
+		String[0] = (UTF8)(CodePoint >> 18) | 0xF0;
+		String[1] = (UTF8)((CodePoint >> 12) & 0x3F) | 0x80;
+		String[2] = (UTF8)((CodePoint >> 6) & 0x3F) | 0x80;
+		String[3] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		return 4;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(U8) capi_UTF8_Encode(UTF8* String, size_t Length, U32 CodePoint)
+{
+	if (CodePoint == 0) return 0;
+
+	if (CodePoint < 0x80)
+	{
+		if (Length < 2) return 0;
+		String[0] = (UTF8)CodePoint & 0x7F;
+		String[1] = 0;
+		return 1;
+	}
+	else if (CodePoint < 0x800)
+	{
+		if (Length < 3) return 0;
+		String[0] = (UTF8)(CodePoint >> 6) | 0xC0;
+		String[1] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		String[2] = 0;
+		return 2;
+	}
+	else if (CodePoint < 0x10000)
+	{
+		if (Length < 4) return 0;
+		String[0] = (UTF8)(CodePoint >> 12) | 0xE0;
+		String[1] = (UTF8)((CodePoint >> 6) & 0x3F) | 0x80;
+		String[2] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		String[3] = 0;
+		return 3;
+	}
+	else if (CodePoint < 0x110000)
+	{
+		if (Length < 5) return 0;
+		String[0] = (UTF8)(CodePoint >> 18) | 0xF0;
+		String[1] = (UTF8)((CodePoint >> 12) & 0x3F) | 0x80;
+		String[2] = (UTF8)((CodePoint >> 6) & 0x3F) | 0x80;
+		String[3] = (UTF8)(CodePoint & 0x3F) | 0x80;
+		String[4] = 0;
+		return 4;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, UTF8* String)
+{
+	U32 CodePoint;
+
+	switch (Units)
+	{
+	case 1:
+		CodePoint = String[0];
+		break;
+	case 2:
+		CodePoint = (String[0] << 6 | (String[1] & 0x3F)) & 0x7FF;
+		break;
+	case 3:
+		CodePoint = (String[0] << 12 | ((String[1] & 0x3F) << 6) | (String[2] & 0x3F)) & 0xFFFF;
+		break;
+	case 4:
+		CodePoint = (String[0] << 18 | ((String[1] & 0x3F) << 12) | ((String[2] & 0x3F) << 6) | (String[3] & 0x3F)) & 0x1FFFFF;
+		break;
+	default:
+		return 0;
+	}
+
+	return CodePoint;
+}
+
+CAPI_FUNC(size_t) capi_StrLenU(UTF8* String)
+{
+	size_t Len, CharUnits;
+
+	if (String == 0) return -1;
+	Len = 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) return Len;
+		String += CharUnits;
+		Len++;
+	}
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrUnitsU(UTF8* String)
+{
+	size_t TotalUnits, CharUnits;
+
+	if (String == 0) return -1;
+	TotalUnits = 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) return TotalUnits;
+		String += CharUnits;
+		TotalUnits += CharUnits;
+	}
+
+	return TotalUnits;
+}
+
+CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, UTF8* Source)
+{
+	U8 CharUnits;
+	size_t Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*Source);
+		if (CharUnits == 0) break;
+		Len += CharUnits;
+		if (Len >= Length)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		switch (CharUnits)
+		{
+		case 1:
+			Destination[0] = Source[0];
+			break;
+		case 2:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			break;
+		case 3:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			Destination[2] = Source[2];
+			break;
+		case 4:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			Destination[2] = Source[2];
+			Destination[3] = Source[3];
+			break;
+		default:
+			break;
+		}
+		Destination += CharUnits;
+		Source += CharUnits;
+	}
+	*Destination = 0;
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, UTF8* Source)
+{
+	size_t Len, cnt;
+	U32 CharUnits;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	while (*Destination != 0)
+	{
+		if (Len >= Length) return Length;
+		CharUnits = capi_UTF8_GetCharUnits(*Destination);
+		if (CharUnits == 0) break;
+		Destination += CharUnits;
+		Len += CharUnits;
+	}
+	cnt = Len;
+
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*Source);
+		if (CharUnits == 0) break;
+		Len += CharUnits;
+		if (Len >= Length)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		switch (CharUnits)
+		{
+		case 1:
+			Destination[0] = Source[0];
+			break;
+		case 2:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			break;
+		case 3:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			Destination[2] = Source[2];
+			break;
+		case 4:
+			Destination[0] = Source[0];
+			Destination[1] = Source[1];
+			Destination[2] = Source[2];
+			Destination[3] = Source[3];
+			break;
+		default:
+			break;
+		}
+		Destination += CharUnits;
+		Source += CharUnits;
+	}
+	*Destination = 0;
+
+	return Len - cnt;
+}
+
+CAPI_FUNC(I32) capi_StrCompareU(UTF8* String1, UTF8* String2)
+{
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint1, CodePoint2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		CharUnits1 = capi_UTF8_GetCharUnits(*String1);
+		CharUnits2 = capi_UTF8_GetCharUnits(*String2);
+
+		if (CharUnits1 == 0) return 0x7FFFFFFF;
+		if (CharUnits2 == 0) return 0x7FFFFFFF;
+
+		CodePoint1 = capi_UTF8_Decode(CharUnits1, String1);
+		CodePoint2 = capi_UTF8_Decode(CharUnits2, String2);
+
+		if (CodePoint1 != CodePoint2)
+		{
+			if (CodePoint1 > CodePoint2) return 1;
+			else return -1;
+		}
+		String1 += CharUnits1;
+		String2 += CharUnits2;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(I32) capi_StrCompareInsensitiveU(UTF8* String1, UTF8* String2)
+{
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint1, CodePoint2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		CharUnits1 = capi_UTF8_GetCharUnits(*String1);
+		CharUnits2 = capi_UTF8_GetCharUnits(*String2);
+
+		if (CharUnits1 == 0) return 0x7FFFFFFF;
+		if (CharUnits2 == 0) return 0x7FFFFFFF;
+
+		CodePoint1 = capi_UTF8_Decode(CharUnits1, String1);
+		CodePoint2 = capi_UTF8_Decode(CharUnits2, String2);
+
+		if ((CodePoint1 > 0x40) && (CodePoint1 < 0x5B)) CodePoint1 += 0x20;
+		else if ((CodePoint1 > 0xFF20) && (CodePoint1 < 0xFF3B)) CodePoint1 -= 0xFEE0;
+		else if ((CodePoint1 > 0xFF40) && (CodePoint1 < 0xFF5B)) CodePoint1 -= 0xFF00;
+
+		if ((CodePoint2 > 0x40) && (CodePoint2 < 0x5B)) CodePoint2 += 0x20;
+		else if ((CodePoint2 > 0xFF20) && (CodePoint2 < 0xFF3B)) CodePoint2 -= 0xFEE0;
+		else if ((CodePoint2 > 0xFF40) && (CodePoint2 < 0xFF5B)) CodePoint2 -= 0xFF00;
+
+		if (CodePoint1 != CodePoint2)
+		{
+			if (CodePoint1 > CodePoint2) return 1;
+			else return -1;
+		}
+		String1 += CharUnits1;
+		String2 += CharUnits2;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(UTF8*) capi_StrFindU(UTF8* String, U32 Delimit)
+{
+	U8 CharUnits;
+	U32 CodePoint;
+
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		CodePoint = capi_UTF8_Decode(CharUnits, String);
+		if (CodePoint == Delimit) return String;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit)
+{
+	size_t I, Length;
+	UTF8* String2, * StrDelimit2;
+	U32 CodePoint1, CodePoint2;
+	U8 CharUnits;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenU(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		String2 = String;
+		StrDelimit2 = StrDelimit;
+
+		while ((*String2 != 0) && (*StrDelimit2 != 0))
+		{
+			CharUnits = capi_UTF8_GetCharUnits(*String2);
+			CodePoint1 = capi_UTF8_Decode(CharUnits, String2);
+			String2 += CharUnits;
+
+			CharUnits = capi_UTF8_GetCharUnits(*StrDelimit2);
+			CodePoint2 = capi_UTF8_Decode(CharUnits, StrDelimit2);
+			StrDelimit2 += CharUnits;
+
+			if (CodePoint1 != CodePoint2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(UTF8* String, UTF8* StrDelimit)
+{
+	size_t I, Length;
+	UTF8* String2, * StrDelimit2;
+	U32 CodePoint1, CodePoint2;
+	U8 CharUnits;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenU(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		String2 = String;
+		StrDelimit2 = StrDelimit;
+
+		while ((*String2 != 0) && (*StrDelimit2 != 0))
+		{
+			CharUnits = capi_UTF8_GetCharUnits(*String2);
+			CodePoint1 = capi_UTF8_Decode(CharUnits, String2);
+			String2 += CharUnits;
+
+			CharUnits = capi_UTF8_GetCharUnits(*StrDelimit2);
+			CodePoint2 = capi_UTF8_Decode(CharUnits, StrDelimit2);
+			StrDelimit2 += CharUnits;
+
+			if ((CodePoint1 > 0x40) && (CodePoint1 < 0x5B)) CodePoint1 += 0x20;
+			else if ((CodePoint1 > 0xFF20) && (CodePoint1 < 0xFF3B)) CodePoint1 -= 0xFEE0;
+			else if ((CodePoint1 > 0xFF40) && (CodePoint1 < 0xFF5B)) CodePoint1 -= 0xFF00;
+
+			if ((CodePoint2 > 0x40) && (CodePoint2 < 0x5B)) CodePoint2 += 0x20;
+			else if ((CodePoint2 > 0xFF20) && (CodePoint2 < 0xFF3B)) CodePoint2 -= 0xFEE0;
+			else if ((CodePoint2 > 0xFF40) && (CodePoint2 < 0xFF5B)) CodePoint2 -= 0xFF00;
+
+			if (CodePoint1 != CodePoint2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF8*) capi_StrSplitU(UTF8* String, U32 Delimit)
+{
+	U8 CharUnits;
+	U32 CodePoint;
+
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF8_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		CodePoint = capi_UTF8_Decode(CharUnits, String);
+
+		if (CodePoint == Delimit)
+		{
+			*String = 0;
+			return String + CharUnits;
+		}
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(void) capi_StrReverseU(UTF8* String)
+{
+	U8 CharUnits;
+	U32 CodePoint1, CodePoint2;
+	size_t I, U;
+	UTF8* ThisChar, * NextChar;
+
+	if (String == 0) return;
+
+	U = capi_StrLenU(String);
+	if (U == 0) return;
+
+	for (; U != 1; U--)
+	{
+		ThisChar = String;
+
+		CharUnits = capi_UTF8_GetCharUnits(*ThisChar);
+		if (CharUnits == 0) return;
+		CodePoint1 = capi_UTF8_Decode(CharUnits, ThisChar);
+
+		NextChar = ThisChar + CharUnits;
+		CharUnits = capi_UTF8_GetCharUnits(*NextChar);
+
+		for (I = U; I != 1; I--)
+		{
+			CodePoint2 = capi_UTF8_Decode(CharUnits, NextChar);
+			ThisChar += capi_UTF8_Encode_Unsafe(ThisChar, CodePoint2);
+
+			NextChar += CharUnits;
+			CharUnits = capi_UTF8_GetCharUnits(*NextChar);
+			if (CharUnits == 0) return;
+		}
+
+		capi_UTF8_Encode_Unsafe(ThisChar, CodePoint1);
+	}
+}
+
+// *                         * //
+// **                       ** //
+// ***  UTF-16LE versions  *** //
+// **                       ** //
+// *                         * //
+
+CAPI_FUNC(U8) capi_UTF16_GetCharUnits(UTF16 Code)
+{
+	if ((Code > 0xD7FF) && (Code < 0xE000)) return 2;
+
+	return 1;
+}
+
+CAPI_FUNC(U8) capi_UTF16_Encode_Unsafe(UTF16* String, U32 CodePoint)
+{
+	if (CodePoint < 0x10000)
+	{
+		String[0] = (UTF16)CodePoint;
+		return 1;
+	}
+
+	CodePoint -= 0x10000;
+	String[0] = (UTF16)(CodePoint >> 10) + 0xD800;
+	String[1] = (UTF16)(CodePoint & 0x3FF) + 0xDC00;
+
+	return 2;
+}
+
+CAPI_FUNC(U8) capi_UTF16_Encode(UTF16* String, size_t Length, U32 CodePoint)
+{
+	if (CodePoint < 0x10000)
+	{
+		if (Length < 2) return 0;
+		String[0] = (UTF16)CodePoint;
+		String[1] = 0;
+		return 1;
+	}
+
+	if (Length < 3) return 0;
+	CodePoint -= 0x10000;
+	String[0] = (UTF16)(CodePoint >> 10) + 0xD800;
+	String[1] = (UTF16)(CodePoint & 0x3FF) + 0xDC00;
+	String[2] = 0;
+
+	return 2;
+}
+
+CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, UTF16* String)
+{
+	if (Units == 1) return String[0];
+	else if (Units == 2) return ((String[0] - 0xD800) << 10) + (String[1] - 0xDC00) + 0x10000;
+	else return 0;
+}
+
+CAPI_FUNC(size_t) capi_StrLenW(UTF16* String)
+{
+	size_t Len, CharUnits;
+
+	if (String == 0) return 0;
+	Len = 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) return Len;
+		String += CharUnits;
+		Len++;
+	}
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrUnitsW(UTF16* String)
+{
+	size_t TotalUnits, CharUnits;
+
+	if (String == 0) return 0;
+	TotalUnits = 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) return TotalUnits;
+		String += CharUnits;
+		TotalUnits += CharUnits;
+	}
+
+	return TotalUnits;
+}
+
+CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, UTF16* Source)
+{
+	U32 CharUnits;
+	size_t Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*Source);
+		if (CharUnits == 0) break;
+		Len += CharUnits;
+		if (Len >= Length)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		Destination[0] = Source[0];
+		if (CharUnits == 2)
+		{
+			Destination[1] = Source[1];
+		}
+		Destination += CharUnits;
+		Source += CharUnits;
+	}
+	*Destination = 0;
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, UTF16* Source)
+{
+	size_t Len, cnt;
+	U32 CharUnits;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	while (*Destination != 0)
+	{
+		if (Len >= Length) return Length;
+		CharUnits = capi_UTF16_GetCharUnits(*Destination);
+		if (CharUnits == 0) break;
+		Destination += CharUnits;
+		Len += CharUnits;
+	}
+	cnt = Len;
+
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*Source);
+		if (CharUnits == 0) break;
+		Len += CharUnits;
+		if (Len >= Length)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		Destination[0] = Source[0];
+		if (CharUnits == 2)
+		{
+			Destination[1] = Source[1];
+		}
+		Destination += CharUnits;
+		Source += CharUnits;
+	}
+	*Destination = 0;
+
+	return Len - cnt;
+}
+
+CAPI_FUNC(I32) capi_StrCompareW(UTF16* String1, UTF16* String2)
+{
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint1, CodePoint2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		CharUnits1 = capi_UTF16_GetCharUnits(*String1);
+		CharUnits2 = capi_UTF16_GetCharUnits(*String2);
+
+		if (CharUnits1 == 0) return 0x7FFFFFFF;
+		if (CharUnits2 == 0) return 0x7FFFFFFF;
+
+		CodePoint1 = capi_UTF16_Decode(CharUnits1, String1);
+		CodePoint2 = capi_UTF16_Decode(CharUnits2, String2);
+
+		if (CodePoint1 != CodePoint2)
+		{
+			if (CodePoint1 > CodePoint2) return 1;
+			else return -1;
+		}
+		String1 += CharUnits1;
+		String2 += CharUnits2;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(I32) capi_StrCompareInsensitiveW(UTF16* String1, UTF16* String2)
+{
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint1, CodePoint2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		CharUnits1 = capi_UTF16_GetCharUnits(*String1);
+		CharUnits2 = capi_UTF16_GetCharUnits(*String2);
+
+		if (CharUnits1 == 0) return 0x7FFFFFFF;
+		if (CharUnits2 == 0) return 0x7FFFFFFF;
+
+		CodePoint1 = capi_UTF16_Decode(CharUnits1, String1);
+		CodePoint2 = capi_UTF16_Decode(CharUnits2, String2);
+
+		if ((CodePoint1 > 0x40) && (CodePoint1 < 0x5B)) CodePoint1 += 0x20;
+		else if ((CodePoint1 > 0xFF20) && (CodePoint1 < 0xFF3B)) CodePoint1 -= 0xFEE0;
+		else if ((CodePoint1 > 0xFF40) && (CodePoint1 < 0xFF5B)) CodePoint1 -= 0xFF00;
+
+		if ((CodePoint2 > 0x40) && (CodePoint2 < 0x5B)) CodePoint2 += 0x20;
+		else if ((CodePoint2 > 0xFF20) && (CodePoint2 < 0xFF3B)) CodePoint2 -= 0xFEE0;
+		else if ((CodePoint2 > 0xFF40) && (CodePoint2 < 0xFF5B)) CodePoint2 -= 0xFF00;
+
+		if (CodePoint1 != CodePoint2)
+		{
+			if (CodePoint1 > CodePoint2) return 1;
+			else return -1;
+		}
+		String1 += CharUnits1;
+		String2 += CharUnits2;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(UTF16*) capi_StrFindW(UTF16* String, U32 Delimit)
+{
+	U8 CharUnits;
+	U32 CodePoint;
+
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		CodePoint = capi_UTF16_Decode(CharUnits, String);
+		if (CodePoint == Delimit) return String;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit)
+{
+	size_t I, Length;
+	UTF16* String2, * StrDelimit2;
+	U32 CodePoint1, CodePoint2;
+	U8 CharUnits;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenW(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		String2 = String;
+		StrDelimit2 = StrDelimit;
+
+		while ((*String2 != 0) && (*StrDelimit2 != 0))
+		{
+			CharUnits = capi_UTF16_GetCharUnits(*String2);
+			CodePoint1 = capi_UTF16_Decode(CharUnits, String2);
+			String2 += CharUnits;
+
+			CharUnits = capi_UTF16_GetCharUnits(*StrDelimit2);
+			CodePoint2 = capi_UTF16_Decode(CharUnits, StrDelimit2);
+			StrDelimit2 += CharUnits;
+
+			if (CodePoint1 != CodePoint2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(UTF16* String, UTF16* StrDelimit)
+{
+	size_t I, Length;
+	UTF16* String2, * StrDelimit2;
+	U32 CodePoint1, CodePoint2;
+	U8 CharUnits;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenW(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		String2 = String;
+		StrDelimit2 = StrDelimit;
+
+		while ((*String2 != 0) && (*StrDelimit2 != 0))
+		{
+			CharUnits = capi_UTF16_GetCharUnits(*String2);
+			CodePoint1 = capi_UTF16_Decode(CharUnits, String2);
+			String2 += CharUnits;
+
+			CharUnits = capi_UTF16_GetCharUnits(*StrDelimit2);
+			CodePoint2 = capi_UTF16_Decode(CharUnits, StrDelimit2);
+			StrDelimit2 += CharUnits;
+
+			if ((CodePoint1 > 0x40) && (CodePoint1 < 0x5B)) CodePoint1 += 0x20;
+			else if ((CodePoint1 > 0xFF20) && (CodePoint1 < 0xFF3B)) CodePoint1 -= 0xFEE0;
+			else if ((CodePoint1 > 0xFF40) && (CodePoint1 < 0xFF5B)) CodePoint1 -= 0xFF00;
+
+			if ((CodePoint2 > 0x40) && (CodePoint2 < 0x5B)) CodePoint2 += 0x20;
+			else if ((CodePoint2 > 0xFF20) && (CodePoint2 < 0xFF3B)) CodePoint2 -= 0xFEE0;
+			else if ((CodePoint2 > 0xFF40) && (CodePoint2 < 0xFF5B)) CodePoint2 -= 0xFF00;
+
+			if (CodePoint1 != CodePoint2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF16*) capi_StrSplitW(UTF16* String, U32 Delimit)
+{
+	U8 CharUnits;
+	U32 CodePoint;
+
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		CharUnits = capi_UTF16_GetCharUnits(*String);
+		if (CharUnits == 0) break;
+		CodePoint = capi_UTF16_Decode(CharUnits, String);
+
+		if (CodePoint == Delimit)
+		{
+			*String = 0;
+			return String + CharUnits;
+		}
+		String += CharUnits;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(void) capi_StrReverseW(UTF16* String)
+{
+	U8 CharUnits;
+	U32 CodePoint1, CodePoint2;
+	size_t I, U;
+	UTF16* ThisChar, * NextChar;
+
+	if (String == 0) return;
+
+	U = capi_StrLenW(String);
+	if (U == 0) return;
+
+	for (; U != 1; U--)
+	{
+		ThisChar = String;
+
+		CharUnits = capi_UTF16_GetCharUnits(*ThisChar);
+		if (CharUnits == 0) return;
+		CodePoint1 = capi_UTF16_Decode(CharUnits, ThisChar);
+
+		NextChar = ThisChar + CharUnits;
+		CharUnits = capi_UTF16_GetCharUnits(*NextChar);
+
+		for (I = U; I != 1; I--)
+		{
+			CodePoint2 = capi_UTF16_Decode(CharUnits, NextChar);
+			ThisChar += capi_UTF16_Encode_Unsafe(ThisChar, CodePoint2);
+
+			NextChar += CharUnits;
+			CharUnits = capi_UTF16_GetCharUnits(*NextChar);
+			if (CharUnits == 0) return;
+		}
+		capi_UTF16_Encode_Unsafe(ThisChar, CodePoint1);
+	}
+}
+
+// *                         * //
+// **                       ** //
+// ***  UTF-32LE versions  *** //
+// **                       ** //
+// *                         * //
+
+CAPI_FUNC(size_t) capi_StrLenL(UTF32* String)
+{
+	size_t Len;
+
+	if (String == 0) return 0;
+	Len = 0;
+
+	while (*String != 0)
+	{
+		Len++;
+		String++;
+	}
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, UTF32* Source)
+{
+	size_t Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	Length--;
+	while (*Source != 0)
+	{
+		if (Len == Length)
+		{
+			Destination[Len] = 0;
+			return Length + 1;
+		}
+		Destination[Len] = *Source;
+		Len++;
+		Source++;
+	}
+	Destination[Len] = 0;
+
+	return Len;
+}
+
+CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, UTF32* Source)
+{
+	size_t Len, I, cnt;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = 0;
+
+	Length--;
+	while (Destination[Len] != 0)
+	{
+		if (Len == Length) return Length + 1;
+		Len++;
+	}
+	cnt = Len;
+
+	I = 0;
+	while (Source[I] != 0)
+	{
+		if (Len == Length)
+		{
+			Destination[Len] = 0;
+			return Length + 1;
+		}
+		Destination[Len] = Source[I];
+		Len++;
+		I++;
+	}
+	Destination[Len] = 0;
+
+	return Len - cnt;
+}
+
+CAPI_FUNC(I32) capi_StrCompareL(UTF32* String1, UTF32* String2)
+{
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		if (*String1 != *String2)
+		{
+			if (*String1 > *String2) return 1;
+			else return -1;
+		}
+		String1++;
+		String2++;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(I32) capi_StrCompareInsensitiveL(UTF32* String1, UTF32* String2)
+{
+	UTF32 Code1, Code2;
+
+	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
+
+	while ((*String1 != 0) && (*String2 != 0))
+	{
+		Code1 = *String1;
+		Code2 = *String2;
+
+		if ((Code1 > 0x40) && (Code1 < 0x5B)) Code1 += 0x20;
+		else if ((Code1 > 0xFF20) && (Code1 < 0xFF3B)) Code1 -= 0xFEE0;
+		else if ((Code1 > 0xFF40) && (Code1 < 0xFF5B)) Code1 -= 0xFF00;
+
+		if ((Code2 > 0x40) && (Code2 < 0x5B)) Code2 += 0x20;
+		else if ((Code2 > 0xFF20) && (Code2 < 0xFF3B)) Code2 -= 0xFEE0;
+		else if ((Code2 > 0xFF40) && (Code2 < 0xFF5B)) Code2 -= 0xFF00;
+
+		if (Code1 != Code2)
+		{
+			if (Code1 > Code2) return 1;
+			else return -1;
+		}
+		String1++;
+		String2++;
+	}
+	if ((*String1 == 0) && (*String2 == 0)) return 0;
+	else
+	{
+		if (*String1 != 0) return 1;
+		else return -1;
+	}
+}
+
+CAPI_FUNC(UTF32*) capi_StrFindL(UTF32* String, U32 Delimit)
+{
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		if (*String == Delimit) return String;
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit)
+{
+	size_t I, Length;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenL(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		while ((String[I] != 0) && (StrDelimit[I] != 0))
+		{
+			if (String[I] != StrDelimit[I]) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(UTF32* String, UTF32* StrDelimit)
+{
+	size_t I, Length;
+	UTF32 Code1, Code2;
+
+	if ((String == 0) || (StrDelimit == 0)) return 0;
+
+	Length = capi_StrLenL(StrDelimit);
+
+	while (*String != 0)
+	{
+		I = 0;
+		while ((String[I] != 0) && (StrDelimit[I] != 0))
+		{
+			Code1 = String[I];
+			Code2 = StrDelimit[I];
+
+			if ((Code1 > 0x40) && (Code1 < 0x5B)) Code1 += 0x20;
+			else if ((Code1 > 0xFF20) && (Code1 < 0xFF3B)) Code1 -= 0xFEE0;
+			else if ((Code1 > 0xFF40) && (Code1 < 0xFF5B)) Code1 -= 0xFF00;
+
+			if ((Code2 > 0x40) && (Code2 < 0x5B)) Code2 += 0x20;
+			else if ((Code2 > 0xFF20) && (Code2 < 0xFF3B)) Code2 -= 0xFEE0;
+			else if ((Code2 > 0xFF40) && (Code2 < 0xFF5B)) Code2 -= 0xFF00;
+
+			if (Code1 != Code2) break;
+			I++;
+		}
+
+		if (I == Length) return String;
+
+		String++;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(UTF32*) capi_StrSplitL(UTF32* String, U32 Delimit)
+{
+	if (String == 0) return 0;
+
+	while (*String != 0)
+	{
+		if (*String == Delimit)
+		{
+			*String = 0;
+			return String + 1;
+		}
+		String = String + 1;
+	}
+
+	return 0;
+}
+
+CAPI_FUNC(void) capi_StrReverseL(UTF32* String)
+{
+	UTF32 Code;
+	UTF32* First, * Last;
+
+	if (String == 0) return;
+
+	Last = First = String;
+
+	while (*Last != 0) Last++;
+	while ((First != Last) && (First != --Last))
+	{
+		Code = *First;
+		*First = *Last;
+		*Last = Code;
+		First = First + 1;
+	}
+}
+
+// *                  * //
+// **                ** //
+// ***  Conversion  *** //
+// **                ** //
+// *                  * //
+
+CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, UTF8* Source)
+{
+	size_t CharCnt, Len;
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		CharUnits1 = capi_UTF8_GetCharUnits(*Source);
+		CodePoint = capi_UTF8_Decode(CharUnits1, Source);
+		CharUnits2 = capi_UTF16_Encode(Destination, Len, CodePoint);
+		if (CharUnits2 == 0) return Length;
+		Len -= CharUnits2;
+		Destination += CharUnits2;
+		Source += CharUnits1;
+		CharCnt++;
+	}
+	*Destination = 0;
+
+	return CharCnt;
+}
+
+CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, UTF8* Source)
+{
+	U8 CharUnits;
+	size_t CharCnt, Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		if (Len == 1)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		CharUnits = capi_UTF8_GetCharUnits(*Source);
+		*Destination = capi_UTF8_Decode(CharUnits, Source);
+		Len--;
+		Source += CharUnits;
+		Destination++;
+		CharCnt++;
+	}
+	*Destination = 0;
+
+	return CharCnt;
+}
+
+CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, UTF16* Source)
+{
+	size_t CharCnt, Len;
+	U8 CharUnits1, CharUnits2;
+	U32 CodePoint;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		CharUnits1 = capi_UTF16_GetCharUnits(*Source);
+		CodePoint = capi_UTF16_Decode(CharUnits1, Source);
+		CharUnits2 = capi_UTF8_Encode(Destination, Len, CodePoint);
+		if (CharUnits2 == 0) return Length;
+		Len -= CharUnits2;
+		Destination += CharUnits2;
+		Source += CharUnits1;
+		CharCnt++;
+	}
+
+	return CharCnt;
+}
+
+CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, UTF16* Source)
+{
+	U8 CharUnits;
+	size_t CharCnt, Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		if (Len == 1)
+		{
+			*Destination = 0;
+			return Length;
+		}
+		CharUnits = capi_UTF16_GetCharUnits(*Source);
+		*Destination = capi_UTF16_Decode(CharUnits, Source);
+		Len--;
+		Source += CharUnits;
+		Destination++;
+		CharCnt++;
+	}
+	*Destination = 0;
+
+	return CharCnt;
+}
+
+CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, UTF32* Source)
+{
+	U8 CharUnits;
+	size_t CharCnt, Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF8_Encode(Destination, Len, *Source);
+		if (CharUnits == 0) return Length;
+		Len -= CharUnits;
+		Destination += CharUnits;
+		Source++;
+		CharCnt++;
+	}
+
+	return CharCnt;
+}
+
+CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, UTF32* Source)
+{
+	U8 CharUnits;
+	size_t CharCnt, Len;
+
+	if ((Destination == 0) || (Source == 0) || (Length == 0)) return -1;
+	Len = Length;
+
+	CharCnt = 0;
+	while (*Source != 0)
+	{
+		CharUnits = capi_UTF16_Encode(Destination, Len, *Source);
+		if (CharUnits == 0) return Length;
+		Len -= CharUnits;
+		Destination += CharUnits;
+		Source++;
+		CharCnt++;
+	}
+
+	return CharCnt;
+}

--- a/Source/strings.c
+++ b/Source/strings.c
@@ -18,7 +18,7 @@
 // **                    ** //
 // *                      * //
 
-CAPI_FUNC(size_t) capi_StrLenA(ASCII* String)
+CAPI_FUNC(size_t) capi_StrLenA(const ASCII* String)
 {
 	size_t Len;
 
@@ -34,7 +34,7 @@ CAPI_FUNC(size_t) capi_StrLenA(ASCII* String)
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, ASCII* Source)
+CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, const ASCII* Source)
 {
 	size_t Len;
 
@@ -58,7 +58,7 @@ CAPI_FUNC(size_t) capi_StrCopyA(ASCII* Destination, size_t Length, ASCII* Source
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, ASCII* Source)
+CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, const ASCII* Source)
 {
 	size_t Len, I, cnt;
 
@@ -90,7 +90,7 @@ CAPI_FUNC(size_t) capi_StrAppendA(ASCII* Destination, size_t Length, ASCII* Sour
 	return Len - cnt;
 }
 
-CAPI_FUNC(I32) capi_StrCompareA(ASCII* String1, ASCII* String2)
+CAPI_FUNC(I32) capi_StrCompareA(const ASCII* String1, const ASCII* String2)
 {
 	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
 
@@ -112,7 +112,7 @@ CAPI_FUNC(I32) capi_StrCompareA(ASCII* String1, ASCII* String2)
 	}
 }
 
-CAPI_FUNC(I32) capi_StrCompareInsensitiveA(ASCII* String1, ASCII* String2)
+CAPI_FUNC(I32) capi_StrCompareInsensitiveA(const ASCII* String1, const ASCII* String2)
 {
 	ASCII Code1, Code2;
 
@@ -142,20 +142,20 @@ CAPI_FUNC(I32) capi_StrCompareInsensitiveA(ASCII* String1, ASCII* String2)
 	}
 }
 
-CAPI_FUNC(ASCII*) capi_StrFindA(ASCII* String, ASCII Delimit)
+CAPI_FUNC(ASCII*) capi_StrFindA(const ASCII* String, ASCII Delimit)
 {
 	if (String == 0) return 0;
 
 	while (*String != 0)
 	{
-		if (*String == Delimit) return String;
+		if (*String == Delimit) return (ASCII*)String;
 		String++;
 	}
 
 	return 0;
 }
 
-CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit)
+CAPI_FUNC(ASCII*) capi_StrFindStrA(const ASCII* String, const ASCII* StrDelimit)
 {
 	size_t I, Length;
 
@@ -172,7 +172,7 @@ CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (ASCII*)String;
 
 		String++;
 	}
@@ -180,7 +180,7 @@ CAPI_FUNC(ASCII*) capi_StrFindStrA(ASCII* String, ASCII* StrDelimit)
 	return 0;
 }
 
-CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(ASCII* String, ASCII* StrDelimit)
+CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(const ASCII* String, const ASCII* StrDelimit)
 {
 	size_t I, Length;
 	ASCII Code1, Code2;
@@ -204,7 +204,7 @@ CAPI_FUNC(ASCII*) capi_StrFindStrInsensitiveA(ASCII* String, ASCII* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (ASCII*)String;
 
 		String++;
 	}
@@ -339,7 +339,7 @@ CAPI_FUNC(U8) capi_UTF8_Encode(UTF8* String, size_t Length, U32 CodePoint)
 	return 0;
 }
 
-CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, UTF8* String)
+CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, const UTF8* String)
 {
 	U32 CodePoint;
 
@@ -364,7 +364,7 @@ CAPI_FUNC(U32) capi_UTF8_Decode(U8 Units, UTF8* String)
 	return CodePoint;
 }
 
-CAPI_FUNC(size_t) capi_StrLenU(UTF8* String)
+CAPI_FUNC(size_t) capi_StrLenU(const UTF8* String)
 {
 	size_t Len, CharUnits;
 
@@ -382,7 +382,7 @@ CAPI_FUNC(size_t) capi_StrLenU(UTF8* String)
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrUnitsU(UTF8* String)
+CAPI_FUNC(size_t) capi_StrUnitsU(const UTF8* String)
 {
 	size_t TotalUnits, CharUnits;
 
@@ -400,7 +400,7 @@ CAPI_FUNC(size_t) capi_StrUnitsU(UTF8* String)
 	return TotalUnits;
 }
 
-CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, UTF8* Source)
+CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, const UTF8* Source)
 {
 	U8 CharUnits;
 	size_t Len;
@@ -449,7 +449,7 @@ CAPI_FUNC(size_t) capi_StrCopyU(UTF8* Destination, size_t Length, UTF8* Source)
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, UTF8* Source)
+CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, const UTF8* Source)
 {
 	size_t Len, cnt;
 	U32 CharUnits;
@@ -508,7 +508,7 @@ CAPI_FUNC(size_t) capi_StrAppendU(UTF8* Destination, size_t Length, UTF8* Source
 	return Len - cnt;
 }
 
-CAPI_FUNC(I32) capi_StrCompareU(UTF8* String1, UTF8* String2)
+CAPI_FUNC(I32) capi_StrCompareU(const UTF8* String1, const UTF8* String2)
 {
 	U8 CharUnits1, CharUnits2;
 	U32 CodePoint1, CodePoint2;
@@ -542,7 +542,7 @@ CAPI_FUNC(I32) capi_StrCompareU(UTF8* String1, UTF8* String2)
 	}
 }
 
-CAPI_FUNC(I32) capi_StrCompareInsensitiveU(UTF8* String1, UTF8* String2)
+CAPI_FUNC(I32) capi_StrCompareInsensitiveU(const UTF8* String1, const UTF8* String2)
 {
 	U8 CharUnits1, CharUnits2;
 	U32 CodePoint1, CodePoint2;
@@ -584,7 +584,7 @@ CAPI_FUNC(I32) capi_StrCompareInsensitiveU(UTF8* String1, UTF8* String2)
 	}
 }
 
-CAPI_FUNC(UTF8*) capi_StrFindU(UTF8* String, U32 Delimit)
+CAPI_FUNC(UTF8*) capi_StrFindU(const UTF8* String, U32 Delimit)
 {
 	U8 CharUnits;
 	U32 CodePoint;
@@ -596,17 +596,17 @@ CAPI_FUNC(UTF8*) capi_StrFindU(UTF8* String, U32 Delimit)
 		CharUnits = capi_UTF8_GetCharUnits(*String);
 		if (CharUnits == 0) break;
 		CodePoint = capi_UTF8_Decode(CharUnits, String);
-		if (CodePoint == Delimit) return String;
+		if (CodePoint == Delimit) return (ASCII*)String;
 		String += CharUnits;
 	}
 
 	return 0;
 }
 
-CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit)
+CAPI_FUNC(UTF8*) capi_StrFindStrU(const UTF8* String, const UTF8* StrDelimit)
 {
 	size_t I, Length;
-	UTF8* String2, * StrDelimit2;
+	const UTF8* String2, * StrDelimit2;
 	U32 CodePoint1, CodePoint2;
 	U8 CharUnits;
 
@@ -634,7 +634,7 @@ CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF8*)String;
 
 		CharUnits = capi_UTF8_GetCharUnits(*String);
 		if (CharUnits == 0) break;
@@ -644,10 +644,10 @@ CAPI_FUNC(UTF8*) capi_StrFindStrU(UTF8* String, UTF8* StrDelimit)
 	return 0;
 }
 
-CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(UTF8* String, UTF8* StrDelimit)
+CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(const UTF8* String, const UTF8* StrDelimit)
 {
 	size_t I, Length;
-	UTF8* String2, * StrDelimit2;
+	const UTF8* String2, * StrDelimit2;
 	U32 CodePoint1, CodePoint2;
 	U8 CharUnits;
 
@@ -683,7 +683,7 @@ CAPI_FUNC(UTF8*) capi_StrFindStrInsensitiveU(UTF8* String, UTF8* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF8*)String;
 
 		CharUnits = capi_UTF8_GetCharUnits(*String);
 		if (CharUnits == 0) break;
@@ -801,14 +801,14 @@ CAPI_FUNC(U8) capi_UTF16_Encode(UTF16* String, size_t Length, U32 CodePoint)
 	return 2;
 }
 
-CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, UTF16* String)
+CAPI_FUNC(U32) capi_UTF16_Decode(U8 Units, const UTF16* String)
 {
 	if (Units == 1) return String[0];
 	else if (Units == 2) return ((String[0] - 0xD800) << 10) + (String[1] - 0xDC00) + 0x10000;
 	else return 0;
 }
 
-CAPI_FUNC(size_t) capi_StrLenW(UTF16* String)
+CAPI_FUNC(size_t) capi_StrLenW(const UTF16* String)
 {
 	size_t Len, CharUnits;
 
@@ -826,7 +826,7 @@ CAPI_FUNC(size_t) capi_StrLenW(UTF16* String)
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrUnitsW(UTF16* String)
+CAPI_FUNC(size_t) capi_StrUnitsW(const UTF16* String)
 {
 	size_t TotalUnits, CharUnits;
 
@@ -844,7 +844,7 @@ CAPI_FUNC(size_t) capi_StrUnitsW(UTF16* String)
 	return TotalUnits;
 }
 
-CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, UTF16* Source)
+CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, const UTF16* Source)
 {
 	U32 CharUnits;
 	size_t Len;
@@ -875,7 +875,7 @@ CAPI_FUNC(size_t) capi_StrCopyW(UTF16* Destination, size_t Length, UTF16* Source
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, UTF16* Source)
+CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, const UTF16* Source)
 {
 	size_t Len, cnt;
 	U32 CharUnits;
@@ -916,7 +916,7 @@ CAPI_FUNC(size_t) capi_StrAppendW(UTF16* Destination, size_t Length, UTF16* Sour
 	return Len - cnt;
 }
 
-CAPI_FUNC(I32) capi_StrCompareW(UTF16* String1, UTF16* String2)
+CAPI_FUNC(I32) capi_StrCompareW(const UTF16* String1, const UTF16* String2)
 {
 	U8 CharUnits1, CharUnits2;
 	U32 CodePoint1, CodePoint2;
@@ -950,7 +950,7 @@ CAPI_FUNC(I32) capi_StrCompareW(UTF16* String1, UTF16* String2)
 	}
 }
 
-CAPI_FUNC(I32) capi_StrCompareInsensitiveW(UTF16* String1, UTF16* String2)
+CAPI_FUNC(I32) capi_StrCompareInsensitiveW(const UTF16* String1, const UTF16* String2)
 {
 	U8 CharUnits1, CharUnits2;
 	U32 CodePoint1, CodePoint2;
@@ -992,7 +992,7 @@ CAPI_FUNC(I32) capi_StrCompareInsensitiveW(UTF16* String1, UTF16* String2)
 	}
 }
 
-CAPI_FUNC(UTF16*) capi_StrFindW(UTF16* String, U32 Delimit)
+CAPI_FUNC(UTF16*) capi_StrFindW(const UTF16* String, U32 Delimit)
 {
 	U8 CharUnits;
 	U32 CodePoint;
@@ -1004,17 +1004,17 @@ CAPI_FUNC(UTF16*) capi_StrFindW(UTF16* String, U32 Delimit)
 		CharUnits = capi_UTF16_GetCharUnits(*String);
 		if (CharUnits == 0) break;
 		CodePoint = capi_UTF16_Decode(CharUnits, String);
-		if (CodePoint == Delimit) return String;
+		if (CodePoint == Delimit) return (UTF16*)String;
 		String += CharUnits;
 	}
 
 	return 0;
 }
 
-CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit)
+CAPI_FUNC(UTF16*) capi_StrFindStrW(const UTF16* String, const UTF16* StrDelimit)
 {
 	size_t I, Length;
-	UTF16* String2, * StrDelimit2;
+	const UTF16* String2, * StrDelimit2;
 	U32 CodePoint1, CodePoint2;
 	U8 CharUnits;
 
@@ -1042,7 +1042,7 @@ CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF16*)String;
 
 		CharUnits = capi_UTF16_GetCharUnits(*String);
 		if (CharUnits == 0) break;
@@ -1052,10 +1052,10 @@ CAPI_FUNC(UTF16*) capi_StrFindStrW(UTF16* String, UTF16* StrDelimit)
 	return 0;
 }
 
-CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(UTF16* String, UTF16* StrDelimit)
+CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(const UTF16* String, const UTF16* StrDelimit)
 {
 	size_t I, Length;
-	UTF16* String2, * StrDelimit2;
+	const UTF16* String2, * StrDelimit2;
 	U32 CodePoint1, CodePoint2;
 	U8 CharUnits;
 
@@ -1091,7 +1091,7 @@ CAPI_FUNC(UTF16*) capi_StrFindStrInsensitiveW(UTF16* String, UTF16* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF16*)String;
 
 		CharUnits = capi_UTF16_GetCharUnits(*String);
 		if (CharUnits == 0) break;
@@ -1167,7 +1167,7 @@ CAPI_FUNC(void) capi_StrReverseW(UTF16* String)
 // **                       ** //
 // *                         * //
 
-CAPI_FUNC(size_t) capi_StrLenL(UTF32* String)
+CAPI_FUNC(size_t) capi_StrLenL(const UTF32* String)
 {
 	size_t Len;
 
@@ -1183,7 +1183,7 @@ CAPI_FUNC(size_t) capi_StrLenL(UTF32* String)
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, UTF32* Source)
+CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, const UTF32* Source)
 {
 	size_t Len;
 
@@ -1207,7 +1207,7 @@ CAPI_FUNC(size_t) capi_StrCopyL(UTF32* Destination, size_t Length, UTF32* Source
 	return Len;
 }
 
-CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, UTF32* Source)
+CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, const UTF32* Source)
 {
 	size_t Len, I, cnt;
 
@@ -1239,7 +1239,7 @@ CAPI_FUNC(size_t) capi_StrAppendL(UTF32* Destination, size_t Length, UTF32* Sour
 	return Len - cnt;
 }
 
-CAPI_FUNC(I32) capi_StrCompareL(UTF32* String1, UTF32* String2)
+CAPI_FUNC(I32) capi_StrCompareL(const UTF32* String1, const UTF32* String2)
 {
 	if ((String1 == 0) || (String2 == 0)) return 0x7FFFFFFF;
 
@@ -1261,7 +1261,7 @@ CAPI_FUNC(I32) capi_StrCompareL(UTF32* String1, UTF32* String2)
 	}
 }
 
-CAPI_FUNC(I32) capi_StrCompareInsensitiveL(UTF32* String1, UTF32* String2)
+CAPI_FUNC(I32) capi_StrCompareInsensitiveL(const UTF32* String1, const UTF32* String2)
 {
 	UTF32 Code1, Code2;
 
@@ -1296,20 +1296,20 @@ CAPI_FUNC(I32) capi_StrCompareInsensitiveL(UTF32* String1, UTF32* String2)
 	}
 }
 
-CAPI_FUNC(UTF32*) capi_StrFindL(UTF32* String, U32 Delimit)
+CAPI_FUNC(UTF32*) capi_StrFindL(const UTF32* String, U32 Delimit)
 {
 	if (String == 0) return 0;
 
 	while (*String != 0)
 	{
-		if (*String == Delimit) return String;
+		if (*String == Delimit) return (UTF32*)String;
 		String++;
 	}
 
 	return 0;
 }
 
-CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit)
+CAPI_FUNC(UTF32*) capi_StrFindStrL(const UTF32* String, const UTF32* StrDelimit)
 {
 	size_t I, Length;
 
@@ -1326,7 +1326,7 @@ CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF32*)String;
 
 		String++;
 	}
@@ -1334,7 +1334,7 @@ CAPI_FUNC(UTF32*) capi_StrFindStrL(UTF32* String, UTF32* StrDelimit)
 	return 0;
 }
 
-CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(UTF32* String, UTF32* StrDelimit)
+CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(const UTF32* String, const UTF32* StrDelimit)
 {
 	size_t I, Length;
 	UTF32 Code1, Code2;
@@ -1363,7 +1363,7 @@ CAPI_FUNC(UTF32*) capi_StrFindStrInsensitiveL(UTF32* String, UTF32* StrDelimit)
 			I++;
 		}
 
-		if (I == Length) return String;
+		if (I == Length) return (UTF32*)String;
 
 		String++;
 	}
@@ -1413,7 +1413,7 @@ CAPI_FUNC(void) capi_StrReverseL(UTF32* String)
 // **                ** //
 // *                  * //
 
-CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, UTF8* Source)
+CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, const UTF8* Source)
 {
 	size_t CharCnt, Len;
 	U8 CharUnits1, CharUnits2;
@@ -1439,7 +1439,7 @@ CAPI_FUNC(size_t) capi_UTF8_To_UTF16(UTF16* Destination, size_t Length, UTF8* So
 	return CharCnt;
 }
 
-CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, UTF8* Source)
+CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, const UTF8* Source)
 {
 	U8 CharUnits;
 	size_t CharCnt, Len;
@@ -1467,7 +1467,7 @@ CAPI_FUNC(size_t) capi_UTF8_To_UTF32(UTF32* Destination, size_t Length, UTF8* So
 	return CharCnt;
 }
 
-CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, UTF16* Source)
+CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, const UTF16* Source)
 {
 	size_t CharCnt, Len;
 	U8 CharUnits1, CharUnits2;
@@ -1492,7 +1492,7 @@ CAPI_FUNC(size_t) capi_UTF16_To_UTF8(UTF8* Destination, size_t Length, UTF16* So
 	return CharCnt;
 }
 
-CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, UTF16* Source)
+CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, const UTF16* Source)
 {
 	U8 CharUnits;
 	size_t CharCnt, Len;
@@ -1520,7 +1520,7 @@ CAPI_FUNC(size_t) capi_UTF16_To_UTF32(UTF32* Destination, size_t Length, UTF16* 
 	return CharCnt;
 }
 
-CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, UTF32* Source)
+CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, const UTF32* Source)
 {
 	U8 CharUnits;
 	size_t CharCnt, Len;
@@ -1542,7 +1542,7 @@ CAPI_FUNC(size_t) capi_UTF32_To_UTF8(UTF8* Destination, size_t Length, UTF32* So
 	return CharCnt;
 }
 
-CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, UTF32* Source)
+CAPI_FUNC(size_t) capi_UTF32_To_UTF16(UTF16* Destination, size_t Length, const UTF32* Source)
 {
 	U8 CharUnits;
 	size_t CharCnt, Len;


### PR DESCRIPTION
Updated the names of the create image functions to be shorter and match their load image counter parts.
Changed variables with the name "Length" in them to "Size" to reflect "number of bytes" and not "Number of characters".
Added string functions, non-specific encoding macros for the C language and the "String" struct for the C++ language.